### PR TITLE
:default attribute values can take procs  (with caveats)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Attributor Changelog
 ============================
 
+next
+----
+
+* Partial support for defining `:default` values through Procs.
+  * Note: this is only "partially" supported the `parent` argument of the Proc will NOT contain the correct attribute parent yet. It will contain a fake class, that will loudly complain about any attempt to use any of its methods.
+  
 2.4.0
 ------
 


### PR DESCRIPTION

This initial support will currently not properly pass the parent object into the first 
argument of the proc. It will always be a FakeClass that will complain (warn) for any
access to any method within it. 
This partial feature is only going to exist until we can retfactor the attribute and type class loads so that they can pass that information along (requires sizable refactoring)

closes #100 

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>