### PR TITLE
Improve handling of Models without defined attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ next
 
 * Partial support for defining `:default` values through Procs.
   * Note: this is only "partially" supported the `parent` argument of the Proc will NOT contain the correct attribute parent yet. It will contain a fake class, that will loudly complain about any attempt to use any of its methods.
-  
+* Fixed `Model.example` to properly handle the case when no attributes are defined on the class.
+* `Model#dump` now issues a warning if its contents have keys for attributes not present on the class. The unknown contents are not dumped.
+
 2.4.0
 ------
 

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -416,6 +416,22 @@ describe Attributor::Model do
 
   end
 
+  context 'with no defined attributes' do
+    let(:model_class) do
+      Class.new(Attributor::Model) do
+        attributes do
+        end
+      end
+    end
 
+    subject(:example) { model_class.example }
+
+    its(:attributes) { should be_empty }
+    
+    it 'dumps as an empty hash' do 
+      example.dump.should eq({})
+    end
+
+  end
 
 end


### PR DESCRIPTION
This is done by:
* Fixing example creation for Models (and Structs) with no attributes.
* Issuing a warning (rather than crashing) in Model#dump
  when encountering an unknown attribute.

Signed-off-by: Dane Jensen <dane@rightscale.com>