### PR TITLE
Support collection queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,23 @@ With Attributor you can:
 
 ### Running specs:
 
-    `bundle exec rake spec`
+    bundle exec rake spec
 
 Note: This should also compute code coverage. See below for details on viewing code coverage.
 
 ### Generating documentation:
 
-    `bundle exec yard`
+    bundle exec yard
 
 ### Computing documentation coverage:
 
-    `bundle exec yardstick 'lib/**/*.rb'`
+    bundle exec yardstick 'lib/**/*.rb'
 
 ### Computing code coverage:
 
-    `bundle exec rake spec`
+    bundle exec rake spec
 
-    `open coverage/index.html`
+    open coverage/index.html
 
 
 ## Contributing to attributor

--- a/spec/attribute_resolver_spec.rb
+++ b/spec/attribute_resolver_spec.rb
@@ -66,6 +66,37 @@ describe Attributor::AttributeResolver do
     end
   end
 
+  context 'querying collection indices from models' do
+    let(:instances) { [instance1, instance2] }
+    let(:instance1) { double('instance1', :ssh_key => ssh_key1) }
+    let(:instance2) { double('instance2', :ssh_key => ssh_key2) }
+    let(:ssh_key1) { double('ssh_key', :name => value) }
+    let(:ssh_key2) { double('ssh_key', :name => 'second') }
+    let(:args) { [path, prefix].compact }
+
+    before { subject.register('instances', instances) }
+
+    it 'resolves the index to the correct member of the collection' do
+      subject.query('instances').should be instances
+      subject.query('instances.at(1).ssh_key').should be ssh_key2
+      subject.query('instances.at(0).ssh_key.name').should be value
+    end
+
+    it 'returns nil for index out of range' do
+      subject.query('instances.at(2)').should be(nil)
+      subject.query('instances.at(-1)').should be(nil)
+    end
+
+    context 'with a prefix' do
+      let(:key) { 'name' }
+      let(:prefix) { '$.instances.at(0).ssh_key'}
+      let(:value) { 'some_name' }
+
+      it 'resolves the index to the correct member of the collection' do
+        subject.query(key, prefix).should be(value)
+      end
+    end
+  end
 
   context 'checking attribute conditions' do
     let(:key) { "instance.ssh_key.name" }

--- a/spec/attribute_resolver_spec.rb
+++ b/spec/attribute_resolver_spec.rb
@@ -154,7 +154,7 @@ describe Attributor::AttributeResolver do
       end
     end
     
-    context 'with a hash condition' do
+    pending 'with a hash condition' do
     end
 
     context 'with a proc condition' do


### PR DESCRIPTION
This allows collection indices to be resolved, which means (among other things) the `required_if` option will work on collection members.