### PR TITLE
Fix `attribute.example` to actually accept native types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ next
 * Fixed bug in `Hash` where the class would refuse to load from another `Attributor::Hash` when there were no keys defined and they were seemingly compatible.
 * Fixed a `Hash.dump` bug where nil attribute values would transitively be `dumpe`d therefore causing a nil dereference.
 * Hardened the `dump`ing of types to support nil values.
+* Fix `attribute.example` to actually accept native types (that are not only Strings)
 
 2.5.0
 ----

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -135,9 +135,6 @@ module Attributor
       if self.options.has_key? :example
         val = self.options[:example]
         case val
-        when ::String
-          # FIXME: spec this properly to use self.type.native_type
-          val
         when ::Regexp
           self.load(val.gen,context)
         when ::Array
@@ -154,7 +151,7 @@ module Attributor
         when nil
           nil
         else
-          raise AttributorException, "unknown example attribute type, got: #{val}"
+          self.load(val)
         end
       else
         if (option_values = self.options[:values])

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -146,12 +146,21 @@ describe Attributor::Attribute do
 
       context 'for a type with a non-String native_type' do
         let(:type) { IntegerAttributeType}
-        let(:example) { /\d{5}/ }
-        it 'coerces the example value properly' do
-          example.should_receive(:gen).and_call_original
-          type.should_receive(:load).and_call_original
-
-          subject.example.should be_kind_of(type.native_type)
+        context 'using a regexp' do
+          let(:example) { /\d{5}/ }
+          it 'coerces the example value properly' do
+            example.should_receive(:gen).and_call_original
+            type.should_receive(:load).and_call_original
+  
+            subject.example.should be_kind_of(type.native_type)
+          end
+        end
+        context 'usign a native Integer type' do
+          let(:example) { 5 }
+          it 'coerces the example value properly' do
+            type.should_receive(:load).and_call_original
+            subject.example.should be_kind_of(type.native_type)
+          end          
         end
       end
     end


### PR DESCRIPTION
closes #106

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>