### PR TITLE
Add custom_data option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Attributor Changelog
 ============================
 
+next
+----
+
+* Add the `:custom_data` option for attributes. This is a hash that is passed through to `describe` - Attributor does no processing or handling of this option.
+
+
 2.6.0
 -----
 

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -96,7 +96,7 @@ module Attributor
     end
 
 
-    TOP_LEVEL_OPTIONS = [ :description, :values, :default, :example, :required, :required_if ]
+    TOP_LEVEL_OPTIONS = [ :description, :values, :default, :example, :required, :required_if, :custom_data ]
     INTERNAL_OPTIONS = [:dsl_compiler,:dsl_compiler_options] # Options we don't want to expose when describing attributes
     def describe(shallow=true)
       description = { }
@@ -284,6 +284,8 @@ module Attributor
         unless definition.is_a?(::Regexp) || definition.is_a?(::String) || definition.is_a?(::Array) || definition.is_a?(::Proc) || definition.nil? || self.type.valid_type?(definition)
           raise AttributorException.new("Invalid example type (got: #{definition.class.name}). It must always match the type of the attribute (except if passing Regex that is allowed for some types)")
         end
+      when :custom_data
+        raise AttributorException.new("custom_data must be a Hash. Got (#{definition})") unless definition.is_a?(::Hash)
       else
         return :unknown # unknown option
       end

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -62,6 +62,16 @@ describe Attributor::Attribute do
       end
     end
 
+    context 'with custom_data' do
+      let(:custom_data) { {loggable: true, visible_in_ui: false} }
+      let(:attribute_options) { {custom_data: custom_data} }
+      its(:describe) { should have_key(:custom_data) }
+
+      it 'keep the custom data attribute' do
+        subject.describe[:custom_data].should == custom_data
+      end
+    end
+
     context 'for an anonymous type (aka: Struct)' do
       let(:attribute_options) { Hash.new }
       let(:attribute) do
@@ -110,6 +120,19 @@ describe Attributor::Attribute do
       }.to raise_error(/Default value doesn't have the correct attribute type/)
     end
 
+    context 'custom_data' do
+      it 'raises when not a hash' do
+        expect {
+          Attributor::Attribute.new(Integer, custom_data: 1)
+        }.to raise_error(/custom_data must be a Hash/)
+      end
+
+      it 'does not raise for hashes' do
+        expect {
+          Attributor::Attribute.new(Integer, custom_data: {loggable: true})
+        }.not_to raise_error
+      end
+    end
   end
 
 


### PR DESCRIPTION
Use this option to store non-Attributor-related metadata about an attribute. This data must be a hash; apart from that, there is no validation.