### PR TITLE
Support procs for required_if; add present_if

### DIFF
--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -221,6 +221,9 @@ module Attributor
         # TODO: support multiple dependencies?
         key_path = requirement.keys.first
         predicate = requirement.values.first
+      when ::Proc
+        key_path = ''
+        predicate = requirement
       else
         # should never get here if the option validation worked...
         raise AttributorException.new("unknown type of dependency: #{requirement.inspect} for #{Attributor.humanize_context(context)}")
@@ -232,6 +235,8 @@ module Attributor
 
       # FIXME: we're having to reconstruct a string context just to use the resolver...smell.
       if AttributeResolver.current.check(requirement_context_string, key_path, predicate)
+        key_path = requirement_context_string if key_path == ''
+
         message = "Attribute #{Attributor.humanize_context(context)} is required when #{key_path} "
 
         # give a hint about what the full path for a relative key_path would be
@@ -240,7 +245,9 @@ module Attributor
         end
 
         if predicate
-          message << "matches #{predicate.inspect}."
+          predicate_display = predicate.is_a?(::Proc) ? "the proc" : predicate.inspect
+
+          message << "matches #{predicate_display}."
         else
           message << "is present."
         end

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -381,7 +381,7 @@ describe Attributor::Attribute do
 
         before { Attributor::AttributeResolver.current.register('instance', instance) }
 
-        let(:attribute_context) { ['$','params','key_material'] }
+        let(:attribute_context) { ['$', 'instance', 'ssh_key'] }
         subject(:errors) { attribute.validate_missing_value(attribute_context) }
 
 
@@ -422,6 +422,29 @@ describe Attributor::Attribute do
           end
         end
 
+        context 'with a proc dependency' do
+          let(:attribute_options) { {:required_if => lambda { |val| val.ssh_key.name == 'default_ssh_key_name' }} }
+
+          context 'where the target attribute exists, and matches the predicate' do
+            let(:value) { 'default_ssh_key_name' }
+
+            it { should_not be_empty }
+
+            its(:first) { should =~ /Attribute #{Regexp.quote(Attributor.humanize_context( attribute_context ))} is required when \$\.instance matches/ }
+          end
+
+          context 'where the target attribute exists, but does not match the predicate' do
+            let(:value) { 'non_default_ssh_key_name' }
+
+            it { should be_empty }
+          end
+
+          context 'where the target attribute does not exist' do
+            let(:ssh_key) { double("ssh_key", :name => nil) }
+
+            it { should be_empty }
+          end
+        end
       end
 
     end

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -89,6 +89,79 @@ describe Attributor::Model do
 
 
       end
+
+      context 'with attributes which have present_if set' do
+        let(:type_example) { default_type_example }
+        let(:default_type_example) { 'example type' }
+
+        let(:model_class) do
+          type_example_binding = type_example
+          present_if_binding = present_if
+
+          Class.new(Attributor::Model) do
+            attributes do
+              attribute :type, String, :example => type_example_binding
+              attribute :length, Integer, :present_if => present_if_binding
+            end
+          end
+        end
+
+        subject(:example) { model_class.example.dump }
+
+        context 'a key condition' do
+          let(:present_if) { 'type' }
+
+          context 'the condition is met' do
+            it 'keeps the attribute' do
+              example[:length].should_not be(nil)
+            end
+          end
+
+          context 'the condition is not met' do
+            let(:type_example) { nil }
+
+            it 'sets the attribute to nil' do
+              example[:length].should be(nil)
+            end
+          end
+        end
+
+        context 'a hash condition' do
+          let(:present_if) { {'type' => default_type_example} }
+
+          context 'the condition is met' do
+            it 'keeps the attribute' do
+              example[:length].should_not be(nil)
+            end
+          end
+
+          context 'the condition is not met' do
+            let(:type_example) { 'not the example' }
+
+            it 'sets the attribute to nil' do
+              example[:length].should be(nil)
+            end
+          end
+        end
+
+        context 'a proc condition' do
+          let(:present_if) { lambda { |val| val.type == default_type_example } }
+
+          context 'the condition is met' do
+            it 'keeps the attribute' do
+              example[:length].should_not be(nil)
+            end
+          end
+
+          context 'the condition is not met' do
+            let(:type_example) { 'not the example' }
+
+            it 'sets the attribute to nil' do
+              example[:length].should be(nil)
+            end
+          end
+        end
+      end
     end
 
 


### PR DESCRIPTION
This is an experimental PR with two separate changes:

1. `required_if` can now be a proc itself. Previously it could be a proc, but only with a key as part of a hash condition: `required_if: {key => proc}`. Now it can just be `required_if: proc`, where the proc gets access to more than one attribute at a time.
2. `present_if` will make an attribute of a model `nil` when dumping if it's set and the condition evaluates to false. We need this, or something like it, because we want to express a two-way constraint for some of our `required_if` attributes: this is always required if it's present, and never present if it's not required.