### PR TITLE
Cleanup and fixes around example generation for `Model`, `Struct` and  `Hash`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ next
 
 * Add the `:custom_data` option for attributes. This is a hash that is passed through to `describe` - Attributor does no processing or handling of this option.
 * Added `Type.family` which returns a more-generic "family name". It's defined for all built-in types, and is included in `Type.describe`.
+* Cleanup and bug fixes around example generation for `Model`, `Struct` and `Hash`.
+  * Avoid creating method accessors for true `Hash` types (only `[]` accessors)
+  * Fix common hash methods created for example instances (to play well with lazy attributes)
+  * Avoid storing the `Hash#insensitive_map` unless insensitivity enabled
 
 2.6.0
 -----

--- a/lib/attributor/example_mixin.rb
+++ b/lib/attributor/example_mixin.rb
@@ -6,9 +6,11 @@ module Attributor
   module ExampleMixin
 
     def self.extended(obj)
-      obj.class.attributes.each do |name, _|
-        obj.define_singleton_method(name) do
-          get(name)
+      if obj.kind_of? Attributor::Model
+        obj.class.attributes.each do |name, _|
+          obj.define_singleton_method(name) do
+            get(name)
+          end
         end
       end
     end
@@ -19,6 +21,37 @@ module Attributor
 
     def lazy_attributes=(val)
       @lazy_attributes = val
+    end
+
+    def [](k)
+      unless @contents.key?(k)
+        proc = lazy_attributes.delete k
+        @contents[k] = proc.call
+      end
+      @contents[k]
+    end
+
+    def []=(k,v)
+      lazy_attributes.delete k
+      @contents[k] = v
+    end
+
+    def each(&block)
+      contents.each(&block)
+    end
+
+    alias_method :each_pair, :each
+
+    def values
+      contents.values
+    end
+
+    def empty?
+      contents.empty?
+    end
+
+    def size
+      keys.size
     end
 
     def keys
@@ -53,9 +86,9 @@ module Attributor
     def contents
       lazy_attributes.keys.each do |key|
         proc = lazy_attributes.delete(key)
-        @contents[key] = proc.call(self)
+        @contents[key] = proc.call(self) unless @contents.key?(key)
       end
-      
+
       super
     end
   end

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -81,10 +81,12 @@ module Attributor
       compiler = dsl_class.new(self, opts)
       compiler.parse(*blocks)
 
-      @insensitive_map = self.keys.keys.each_with_object({}) do |k, map|
-        map[k.downcase] = k
+      if opts[:case_insensitive_load] == true
+        @insensitive_map = self.keys.keys.each_with_object({}) do |k, map|
+          map[k.downcase] = k
+        end
       end
-
+      
       compiler
     end
 
@@ -400,9 +402,7 @@ module Attributor
       @contents.each(&block)
     end
 
-    def each_pair(&block)
-      @contents.each_pair(&block)
-    end
+    alias_method :each_pair, :each
 
     def size
       @contents.size
@@ -428,7 +428,7 @@ module Attributor
     def merge(h)
       case h
       when self.class
-        self.class.new(@contents.merge(h.contents))
+        self.class.new(contents.merge(h.contents))
       when Attributor::Hash
         raise ArgumentError, "cannot merge Attributor::Hash instances of different types" unless h.is_a?(self.class)
       else

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -91,10 +91,6 @@ describe Attributor::Hash do
         example.should_not respond_to(:something)
       end
 
-      it 'understands lazy attributes when setting' do
-
-      end
-
     end
 
     context 'using a non array context' do

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -35,6 +35,68 @@ describe Attributor::Hash do
         example.values.all? {|v| v.kind_of? Integer}.should be(true)
       end
     end
+
+    context 'for a Hash with defined keys' do
+      let(:name) { 'bob' }
+      let(:something) { 'else' }
+
+      subject(:example) { HashWithStrings.example(name: name, something: something) }
+
+      context 'resolves a lazy attributes on demand' do
+        before { example.lazy_attributes.keys.should eq [:name, :something] }
+        after { example.lazy_attributes.keys.should eq [:something] }
+
+        it 'using get' do
+          example.get(:name).should be name
+        end
+        it 'using []' do
+          example[:name].should be name
+        end
+
+        it 'using set' do
+          example.set :name, 'not bob'
+          example.get(:name).should == 'not bob'
+        end
+        it 'using []=' do
+          example[:name] = 'not bob'
+          example[:name].should == 'not bob'
+        end
+      end
+
+      its(:size) { should eq 2 }
+      its(:values) { should =~ [name, something] }
+      its(:keys) { should =~ [:name, :something] }
+      it do
+        should_not be_empty
+      end
+
+      it 'responds to key? correctly' do
+        example.key?(:name).should be(true)
+        example.key?(:something).should be(true)
+      end
+
+      it 'enumerates the contents' do
+        example.collect {|k,v| k }.should eq [:name, :something ]
+      end
+
+      it 'enumerates the contents using each_pair' do
+        pairs = []
+        example.each_pair {|pair| pairs << pair }
+        pairs.should =~ [ [:name, name], [:something, something] ]
+      end
+
+      its(:contents){ should eq ({name: name, something: something}) }
+      it 'does not create methods for the keys' do
+        example.should_not respond_to(:name)
+        example.should_not respond_to(:something)
+      end
+
+      it 'understands lazy attributes when setting' do
+
+      end
+
+    end
+
     context 'using a non array context' do
       it 'should work for hashes with key/value types' do
         expect{ Attributor::Hash.of(key:String,value:String).example("Not an Array") }.to_not raise_error
@@ -555,7 +617,9 @@ describe Attributor::Hash do
     end
   end
 
-  context 'with case_insensitive_load option for string keys' do
+  context 'case_insensitive_load option' do
+    let(:case_insensitive) { true }
+    let(:type) { Attributor::Hash.of(key: String).construct(block, case_insensitive_load: case_insensitive) }
     let(:block) do
       proc do
         key 'downcase', Integer
@@ -563,19 +627,31 @@ describe Attributor::Hash do
         key 'CamelCase', Integer
       end
     end
-
-    let(:type) { Attributor::Hash.of(key: String).construct(block, case_insensitive_load: true) }
-
     let(:input) { {'DOWNCASE' => 1, 'upcase' => 2, 'CamelCase' => 3} }
-
     subject(:output) { type.load(input) }
 
-    it 'maps the incoming keys to defined keys, regardless of case' do
-      output['downcase'].should eq(1)
-      output['UPCASE'].should eq(2)
-      output['CamelCase'].should eq(3)
-    end
+    context 'when defined' do
 
+      it 'maps the incoming keys to defined keys, regardless of case' do
+        output['downcase'].should eq(1)
+        output['UPCASE'].should eq(2)
+        output['CamelCase'].should eq(3)
+      end
+      it 'has loaded the (internal) insensitive_map upon building the definition' do
+        type.definition 
+        type.insensitive_map.should be_kind_of(::Hash)
+        type.insensitive_map.keys.should =~ ["downcase","upcase","camelcase"]
+      end
+    end
+  
+    context 'when not defined' do
+      let(:case_insensitive) { false }
+
+      it 'skips the loading of the (internal) insensitive_map' do
+        type.definition 
+        type.insensitive_map.should be_nil
+      end
+    end
   end
 
   context 'with allow_extra keys option' do


### PR DESCRIPTION
* Avoid creating method accessors for true `Hash` types (only `[]` accessors)
* Fix common hash methods created for example instances (to play well with lazy attributes)
* Avoid storing the `Hash#insensitive_map` unless insensitivity enabled

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>