### PR TITLE
Describing attributes embed an example for leaf types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ next
 * Added support to `Collection.load` for any value that responds to `to_a`
 * Fixed `Collection.validate` to complain when value object is not a valida type
 * Fixed bug where defining an attribute that references a `Collection` would not properly support defining sub-attributes in a provided block.
+* Enhanced the type/attribute `describe` methods of types so that they generate an example if an `example` argument is passed in.
+  * Complex (sub-structured) types will not output examples, only 'leaf' ones.
 
 
 2.6.1

--- a/lib/attributor.rb
+++ b/lib/attributor.rb
@@ -14,7 +14,7 @@ module Attributor
   require_relative 'attributor/attribute_resolver'
 
   require_relative 'attributor/example_mixin'
-  
+
   require_relative 'attributor/extensions/randexp'
 
 
@@ -45,16 +45,16 @@ module Attributor
   end
 
   def self.humanize_context( context )
-    raise "NIL CONTEXT PASSED TO HUMANZE!!" unless context
+    return "" unless context
 
     if context.kind_of? ::String
       context = Array(context)
     end
 
     unless context.is_a? Enumerable
-      raise "INVALID CONTEXT!!! (got: #{context.inspect})" 
+      raise "INVALID CONTEXT!!! (got: #{context.inspect})"
     end
-    
+
     begin
       return context.join('.')
     rescue Exception => e
@@ -73,10 +73,10 @@ module Attributor
 
   require_relative 'attributor/families/numeric'
   require_relative 'attributor/families/temporal'
-  
+
   require_relative 'attributor/types/container'
   require_relative 'attributor/types/object'
-  
+
   require_relative 'attributor/types/bigdecimal'
   require_relative 'attributor/types/integer'
   require_relative 'attributor/types/string'
@@ -90,7 +90,7 @@ module Attributor
   require_relative 'attributor/types/hash'
   require_relative 'attributor/types/model'
   require_relative 'attributor/types/struct'
-  
+
 
   require_relative 'attributor/types/csv'
   require_relative 'attributor/types/ids'

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -80,7 +80,7 @@ module Attributor
     end
 
     def dump(value, **opts)
-      type.dump(value, opts)
+      type.dump(value, **opts)
     end
 
 
@@ -123,7 +123,7 @@ module Attributor
       description[:type] = self.type.describe(shallow, example: example )
       # Move over any example from the type, into the attribute itself
       if ( ex = description[:type].delete(:example) )
-        description[:example] = ex
+        description[:example] = self.dump( ex ).to_s
       end
 
       description
@@ -136,6 +136,8 @@ module Attributor
         ctx = Attributor.humanize_context(context)
         seed, _ = Digest::SHA1.digest(ctx).unpack("QQ")
         Random.srand(seed)
+      else
+        context = Attributor::DEFAULT_ROOT_CONTEXT
       end
 
       if self.options.has_key? :example

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -3,14 +3,14 @@
 module Attributor
 
   class FakeParent < ::BasicObject
-    
+
     def method_missing(name, *args)
       ::Kernel.warn "Warning, you have tried to access the '#{name}' method of the 'parent' argument of a Proc-defined :default values." +
                     "Those Procs should completely ignore the 'parent' attribute for the moment as it will be set to an " +
                     "instance of a useless class (until the framework can provide such functionality)"
       nil
     end
-    
+
     def class
       FakeParent
     end
@@ -98,7 +98,7 @@ module Attributor
 
     TOP_LEVEL_OPTIONS = [ :description, :values, :default, :example, :required, :required_if, :custom_data ]
     INTERNAL_OPTIONS = [:dsl_compiler,:dsl_compiler_options] # Options we don't want to expose when describing attributes
-    def describe(shallow=true)
+    def describe(shallow=true, example: nil )
       description = { }
       # Clone the common options
       TOP_LEVEL_OPTIONS.each do |option_name|
@@ -109,6 +109,7 @@ module Attributor
       if ( ex_def = description.delete(:example) )
         description[:example_definition] = ex_def
       end
+
       special_options = self.options.keys - TOP_LEVEL_OPTIONS - INTERNAL_OPTIONS
       description[:options] = {} unless special_options.empty?
       special_options.each do |opt_name|
@@ -119,7 +120,12 @@ module Attributor
         description[:options][:reference] = reference.name
       end
 
-      description[:type] = self.type.describe(shallow)
+      description[:type] = self.type.describe(shallow, example: example )
+      # Move over any example from the type, into the attribute itself
+      if ( ex = description[:type].delete(:example) )
+        description[:example] = ex
+      end
+
       description
     end
 

--- a/lib/attributor/type.rb
+++ b/lib/attributor/type.rb
@@ -10,9 +10,9 @@ module Attributor
 
 
     module ClassMethods
-  
-      # Does this type support the generation of subtypes? 
-      def constructable? 
+
+      # Does this type support the generation of subtypes?
+      def constructable?
         false
       end
 
@@ -20,7 +20,7 @@ module Attributor
       def load(value,context=Attributor::DEFAULT_ROOT_CONTEXT, **options)
         return nil if value.nil?
         unless value.is_a?(self.native_type)
-          raise Attributor::IncompatibleTypeError, context: context, value_type: value.class, type: self 
+          raise Attributor::IncompatibleTypeError, context: context, value_type: value.class, type: self
         end
 
         value
@@ -89,7 +89,7 @@ module Attributor
 
 
       def generate_subcontext(context, subname)
-        context + [subname] 
+        context + [subname]
       end
 
       def dsl_compiler
@@ -105,15 +105,17 @@ module Attributor
       end
 
       # Default describe for simple types...only their name (stripping the base attributor module)
-      def describe(root=false)
+      def describe(root=false, example: nil)
         type_name = self.ancestors.find { |k| k.name && !k.name.empty? }.name
-        {
+        hash = {
           name: type_name.gsub(Attributor::MODULE_PREFIX_REGEX, ''),
           family: self.family,
           id: self.id
         }
+        hash[:example] = example if example
+        hash
       end
-      
+
       def id
         return nil if self.name.nil?
         self.name.gsub('::'.freeze,'-'.freeze)

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -101,10 +101,11 @@ module Attributor
       values.collect { |value| member_attribute.dump(value,opts) }
     end
 
-    def self.describe(shallow=false)
+    def self.describe(shallow=false, example: nil)
       hash = super(shallow)
       hash[:options] = {} unless hash[:options]
-      hash[:member_attribute] = self.member_attribute.describe
+      member_example = example.first if example
+      hash[:member_attribute] = self.member_attribute.describe(true, example: member_example )
       hash
     end
 

--- a/lib/attributor/types/csv.rb
+++ b/lib/attributor/types/csv.rb
@@ -29,9 +29,16 @@ module Attributor
       return collection.join(',')
     end
 
+    def self.describe(shallow=false, example: nil)
+      hash = super(shallow)
+      hash.delete(:member_attribute)
+      hash[:example] = example if example
+      hash
+    end
+
     def self.family
       Collection.family
     end
-    
+
   end
 end

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -148,8 +148,8 @@ module Attributor
           value = values.fetch(sub_attribute_name) do
             sub_attribute.example(sub_context, parent: parent)
           end
-
           sub_attribute.load(value,sub_context)
+
         end
 
 
@@ -365,8 +365,8 @@ module Attributor
       object.validate(context)
     end
 
-    def self.describe(shallow=false)
-      hash = super
+    def self.describe(shallow=false, example: nil)
+      hash = super(shallow)
 
       if key_type
         hash[:key] = {type: key_type.describe(true)}
@@ -374,10 +374,11 @@ module Attributor
 
       if self.keys.any?
         # Spit keys if it's the root or if it's an anonymous structures
-        if ( !shallow || self.name == nil) && self.keys.any?
+        if ( !shallow || self.name == nil)
           # FIXME: change to :keys when the praxis doc browser supports displaying those. or josep's demo is over.
           hash[:attributes] = self.keys.each_with_object({}) do |(sub_name, sub_attribute), sub_attributes|
-            sub_attributes[sub_name] = sub_attribute.describe(true)
+            sub_example = example.get(sub_name) if example
+            sub_attributes[sub_name] = sub_attribute.describe(true, example: sub_example)
           end
         end
       else

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -44,7 +44,7 @@ end
 
 class Cormorant < Attributor::Model
   attributes do
-    attribute :name, String, :default => "Mr. Cormor", :description => "Cormorant name", :example => /[:name:]/
+    attribute :name, String, :description => "Name of the Cormorant", :example => /[:name:]/
     attribute :timestamps do
       attribute :born_at, DateTime
       attribute :died_at, DateTime, example: Proc.new {|timestamps| timestamps.born_at + 10}

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -44,8 +44,12 @@ end
 
 class Cormorant < Attributor::Model
   attributes do
-    attribute :id, Integer, :description => "ID of the Cormorant"
-    attribute :name, String, :description => "Name of the Cormorant"
+    attribute :name, String, :default => "Mr. Cormor", :description => "Cormorant name", :example => /[:name:]/
+    attribute :timestamps do
+      attribute :born_at, DateTime
+      attribute :died_at, DateTime, example: Proc.new {|timestamps| timestamps.born_at + 10}
+    end
+
     # This will be a collection of arbitrary Ruby Objects
     attribute :fish, Attributor::Collection, :description => "All kinds of fish for feeding the babies"
 

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), 'spec_helper.rb')
 
 describe Attributor::Type do
 
-  subject(:test_type) do 
+  subject(:test_type) do
     Class.new do
       include Attributor::Type
       def self.native_type
@@ -42,7 +42,7 @@ describe Attributor::Type do
         test_type.load(value).should be(value)
       end
     end
-    
+
     context "when given a value that is of native_type" do
       let(:value) { "one" }
       it 'returns the value' do
@@ -53,7 +53,7 @@ describe Attributor::Type do
     context "when given a value that is not of native_type" do
       let(:value) { 1 }
       let(:context) { ['top','sub'] }
-      
+
       it 'raises an exception' do
         expect { test_type.load(value,context) }.to raise_error( Attributor::IncompatibleTypeError, /cannot load values of type Fixnum.*while loading top.sub/)
       end
@@ -149,6 +149,7 @@ describe Attributor::Type do
   end
 
   context 'describe' do
+    let(:example){ "Foo" }
     subject(:description) { test_type.describe }
     it 'outputs the type name' do
       description[:name].should eq(test_type.name)
@@ -156,6 +157,15 @@ describe Attributor::Type do
     it 'outputs the type id' do
       description[:id].should eq(test_type.name)
     end
+
+    context 'with an example' do
+      subject(:description) { test_type.describe(example: example) }
+      it 'includes it in the :example key' do
+        description.should have_key(:example)
+        description[:example].should be(example)
+      end
+    end
+
   end
 
 end

--- a/spec/types/collection_spec.rb
+++ b/spec/types/collection_spec.rb
@@ -310,4 +310,23 @@ describe Attributor::Collection do
     end
 
   end
+
+  context '.describe' do
+    let(:type){ Attributor::Collection.of(Attributor::String)}
+    let(:example){ nil }
+    subject(:described){ type.describe(example: example)}
+    it 'includes the member_attribute' do
+      described.should have_key(:member_attribute)
+      described[:member_attribute].should_not have_key(:example)
+    end
+
+    context 'with an example' do
+      let(:example){ type.example }
+      it 'includes the member_attribute with an example from the first member' do
+        described.should have_key(:member_attribute)
+        described[:member_attribute].should have_key(:example)
+        described[:member_attribute].should eq( type.member_attribute.describe(example: example.first ) )
+      end
+    end
+  end
 end

--- a/spec/types/csv_spec.rb
+++ b/spec/types/csv_spec.rb
@@ -43,10 +43,21 @@ describe Attributor::CSV do
     it 'dumps non-Integer values also' do
       csv.dump(str_vals).should eq(str_vals.join(','))
     end
-    
+
     it 'dumps nil values as nil' do
       csv.dump(nil).should eq(nil)
     end
   end
 
+  context '.describe' do
+    let(:example){ csv.example }
+    subject(:described){ csv.describe(example: example)}
+    it 'adds a string example if an example is passed' do
+      described.should have_key(:example)
+      described[:example].should eq(csv.dump(example))
+    end
+    it 'ensures no member_attribute key exists from underlying Collection' do
+      described.should_not have_key(:member_attribute)
+    end
+  end
 end

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -527,7 +527,8 @@ describe Attributor::Hash do
           description[:attributes].keys.should =~ type.keys.keys
           description[:attributes].each do |name,sub_description|
             sub_description.should have_key(:example)
-            sub_description[:example].should eq( example[name] )
+            val = type.attributes[name].dump( example[name] ).to_s
+            sub_description[:example].should eq( val )
           end
         end
       end

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -485,7 +485,8 @@ describe Attributor::Hash do
   end
 
   context '.describe' do
-    subject(:description) { type.describe }
+    let(:example){ nil }
+    subject(:description) { type.describe(example: example) }
     context 'for hashes with key and value types' do
       it 'describes the type correctly' do
         description[:name].should eq('Hash')
@@ -517,6 +518,18 @@ describe Attributor::Hash do
         attrs['1'].should eq(type: {name: 'Integer', id: 'Attributor-Integer', family: 'numeric'}, options: {min: 1, max: 20}  )
         attrs['some_date'].should eq(type: {name: 'DateTime', id: 'Attributor-DateTime', family: 'temporal'})
         attrs['defaulted'].should eq(type: {name: 'String', id: 'Attributor-String', family: 'string'}, default: 'default value')
+      end
+
+      context 'with an example' do
+        let(:example){ type.example }
+
+        it 'should have the matching example for each leaf key' do
+          description[:attributes].keys.should =~ type.keys.keys
+          description[:attributes].each do |name,sub_description|
+            sub_description.should have_key(:example)
+            sub_description[:example].should eq( example[name] )
+          end
+        end
       end
     end
   end

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -414,7 +414,7 @@ describe Attributor::Model do
       it 'supports defining sub-attributes using the proper reference' do
         struct.attributes[:neighbors].options[:required].should be true
         struct.attributes[:neighbors].type.member_attribute.type.attributes.keys.should =~ [:name, :age]
-        
+
         name_options = struct.attributes[:neighbors].type.member_attribute.type.attributes[:name].options
         name_options[:required].should be true
         name_options[:description].should eq 'Name of the Cormorant'


### PR DESCRIPTION
* Calling `describe` of an attribute can now take an example object, which will be passed down when describing sub-attributes.
* “Leaf” types should output an appropriate example when describing (based on the passed `:example` parameter)
* Complex attributes should not output an example themselves, but should take care of passing down the right subtree of the example when describing its sub-attributes (recursive)
* If no `:example` attribute is passed in the `describe` method the description will never include an example.

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>