### PR TITLE
Collection.validate checks incoming type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ next
 * Changed the schema for describing `Hash` to use `attributes` instead of `keys`
   * It makes more sense, and it is compatible with Model and Structs too.
 * Undefine JRuby package helper methods in `Model` (org, java...)
-* Added support to `Collection.load` for any value that responds to `to_a`/
+* Added support to `Collection.load` for any value that responds to `to_a`
+* Fixed `Collection.validate` to complain when value object is not a valida type
 
 2.6.1
 -----

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -28,7 +28,7 @@ module Attributor
     def self.family
       'array'
     end
-    
+
     def self.member_type
       @member_type ||= Attributor::Object
     end
@@ -97,7 +97,7 @@ module Attributor
     end
 
 
-    def self.constructable? 
+    def self.constructable?
       true
     end
 
@@ -133,6 +133,16 @@ module Attributor
 
     # @param values [Array] Array of values to validate
     def self.validate(values, context=Attributor::DEFAULT_ROOT_CONTEXT, attribute=nil)
+
+      unless self.valid_type?(values)
+        descriptive_type =if self.member_type != Object
+          "Collection.of(#{self.member_type})"
+        else
+           self
+        end
+        raise Attributor::IncompatibleTypeError, context: context, value_type: values.class, type: descriptive_type
+      end
+
       values.each_with_index.collect do |value, i|
         subcontext = context + ["at(#{i})"]
         self.member_attribute.validate(value, subcontext)

--- a/spec/types/collection_spec.rb
+++ b/spec/types/collection_spec.rb
@@ -244,19 +244,29 @@ describe Attributor::Collection do
   end
 
   context '.validate' do
-    let(:collection_members) { [1, 2, 'three'] }
-    let(:expected_errors) { ["error 1", "error 2", "error 3"]}
+    context 'compatible type values' do
+      let(:collection_members) { [1, 2, 'three'] }
+      let(:expected_errors) { ["error 1", "error 2", "error 3"]}
 
-    before do
-      collection_members.zip(expected_errors).each do |member, expected_error|
-        type.member_attribute.should_receive(:validate).
-          with(member,an_instance_of(Array)). # we don't care about the exact context here
-          and_return([expected_error])
+      before do
+        collection_members.zip(expected_errors).each do |member, expected_error|
+          type.member_attribute.should_receive(:validate).
+            with(member,an_instance_of(Array)). # we don't care about the exact context here
+            and_return([expected_error])
+        end
+      end
+
+      it 'validates members' do
+        type.validate(collection_members).should =~ expected_errors
       end
     end
-
-    it 'validates members' do
-      type.validate(collection_members).should =~ expected_errors
+    context 'invalid incoming types' do
+      subject(:type) { Attributor::Collection.of(Integer) }
+      it 'raise an exception' do
+        expect{
+          type.validate( {one: :two} )
+        }.to raise_error(Attributor::IncompatibleTypeError, /cannot load values of type Hash/)
+      end
     end
   end
 


### PR DESCRIPTION
* Fixed `Collection.validate` to complain when value object is not a valida type

Fixes #124 

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>