### PR TITLE
Fix attribute creation for collections that reference other collections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ next
 * Undefine JRuby package helper methods in `Model` (org, java...)
 * Added support to `Collection.load` for any value that responds to `to_a`
 * Fixed `Collection.validate` to complain when value object is not a valida type
+* Fixed bug where defining an attribute that references a `Collection` would not properly support defining sub-attributes in a provided block.
+
 
 2.6.1
 -----

--- a/lib/attributor/dsl_compiler.rb
+++ b/lib/attributor/dsl_compiler.rb
@@ -100,7 +100,13 @@ module Attributor
       # determine attribute type to use
       if attr_type.nil?
         if block_given?
-          attr_type = Attributor::Struct
+          attr_type = if inherited_attribute && inherited_attribute.type < Attributor::Collection
+            # override the reference to be the member_attribute's type for collections
+            opts[:reference] = inherited_attribute.type.member_attribute.type
+            Attributor::Collection.of(Struct)
+          else
+            Attributor::Struct
+          end
         elsif inherited_attribute
           attr_type = inherited_attribute.type
         else

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -21,6 +21,18 @@ module Attributor
       end
     end
 
+    @options = {}
+
+    def self.inherited(klass)
+      klass.instance_eval do
+        @options = {}
+      end
+    end
+
+    def self.options
+      @options
+    end
+
     def self.native_type
       return ::Array
     end
@@ -101,8 +113,8 @@ module Attributor
       true
     end
 
-    def self.construct(constructor_block, options)
 
+    def self.construct(constructor_block, options)
       member_options =  (options[:member_options]  || {} ).clone
       if options.has_key?(:reference) && !member_options.has_key?(:reference)
         member_options[:reference] = options[:reference]
@@ -138,7 +150,7 @@ module Attributor
         descriptive_type =if self.member_type != Object
           "Collection.of(#{self.member_type})"
         else
-           self
+          self
         end
         raise Attributor::IncompatibleTypeError, context: context, value_type: values.class, type: descriptive_type
       end

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -638,7 +638,6 @@ describe Attributor::Attribute do
       let(:type) { Attributor::Collection.of(member_type) }
       let(:member_options) { {} }
 
-
       context 'the member_attribute of that type' do
         subject(:member_attribute) { attribute.type.member_attribute }
         it { should be_kind_of(Attributor::Attribute)}

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -40,11 +40,12 @@ class Turducken < Attributor::Model
   end
 end
 
-
 # http://en.wikipedia.org/wiki/Cormorant
 
 class Cormorant < Attributor::Model
   attributes do
+    attribute :id, Integer, :description => "ID of the Cormorant"
+    attribute :name, String, :description => "Name of the Cormorant"
     # This will be a collection of arbitrary Ruby Objects
     attribute :fish, Attributor::Collection, :description => "All kinds of fish for feeding the babies"
 
@@ -53,7 +54,7 @@ class Cormorant < Attributor::Model
 
     # This will be a collection of instances of an anonymous Struct class, each having two well-defined attributes
 
-    attribute :babies, Attributor::Collection.of(Attributor::Struct), :description => "All the babies", :member_options => {:identity => 'name'} do
+    attribute :babies, Attributor::Collection.of(Attributor::Struct), :description => "All the babies", :member_options => {:identity => :name} do
       attribute :name, Attributor::String, :example => /[:name]/, :description => "The name of the baby cormorant"
       attribute :months, Attributor::Integer, :default => 0, :min => 0, :description => "The age in months of the baby cormorant"
       attribute :weight, Attributor::Float, :example => /\d{1,2}\.\d{3}/, :description => "The weight in kg of the baby cormorant"


### PR DESCRIPTION
Defining an attribute that references a Collection would not properly support defining sub-attributes in a provided block.

Fixes #118

Signed-off-by: Dane Jensen <dane.jensen@gmail.com>