### PR TITLE
Validation of generated attribute examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ next
   * Complex (sub-structured) types will not output examples, only 'leaf' ones.
 * Improved handling of exceptions during attribute definitions for `Hash`/`Model` that would previously leave the set of attributes in an undefined state. Now, any attempts to use the type will throw an `InvalidDefinition` exception and include the original exception. (#127)
 * Removed `undef :empty?` from `Model`
-* Made `Collection` a subclass of Array, and `load` create new instances of it. 
+* Made `Collection` a subclass of Array, and `load` create new instances of it.
+* Built in proper loading and validation of any `Attribute#example` when the `:example` option is used.
 
 2.6.1
 -----

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -29,7 +29,7 @@ context 'attributes' do
       it 'throws InvalidDefinition for subsequent access' do
         broken_model.attributes rescue nil
 
-        lambda { 
+        lambda {
           broken_model.attributes
         }.should raise_error(Attributor::InvalidDefinition)
       end
@@ -45,7 +45,7 @@ context 'attributes' do
 
     end
   end
-  
+
   context 'default options' do
     subject(:options) { type.options }
     it 'has allow_extra false' do
@@ -515,7 +515,7 @@ context 'attributes' do
       let(:example_hash) { {:key => "value"} }
       let(:options) { { example: proc { example_hash } } }
       it 'uses the hash' do
-        attribute.example.should be(example_hash)
+        attribute.example.should eq(example_hash)
       end
     end
 

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -25,7 +25,7 @@ describe Attributor::Model do
       it 'throws InvalidDefinition for subsequent access' do
         broken_model.attributes rescue nil
 
-        lambda { 
+        lambda {
           broken_model.attributes
         }.should raise_error(Attributor::InvalidDefinition)
       end
@@ -354,13 +354,12 @@ describe Attributor::Model do
         its(:validate) { should be_empty}
       end
 
-      context 'that are invalid' do
-        subject(:person) do
-          # TODO: support this? Person.example(title: 'dude', address: {name: 'ME'} )
-
-          obj = Person.example(title: 'dude')
-          obj.address.state = 'ME'
-          obj
+      context 'that are both invalid' do
+        subject(:person){ Person.load( name: 'Joe', title: 'dude', okay: true )}
+        let(:address){ Address.load( name: '1 Main St', state: 'ME' )}
+        before do
+          person.address = address
+          address.person = person
         end
 
         its(:validate) { should have(2).items }
@@ -370,9 +369,7 @@ describe Attributor::Model do
           title_error.should =~ /^Attribute person\.title:/
           state_error.should =~ /^Attribute person\.address\.state:/
         end
-
       end
-
 
     end
   end


### PR DESCRIPTION
Built in proper loading and validation of any `Attribute#example` when the `:example` option is used.

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>