### PR TITLE
Fix `:example` option in an attribute to work for collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next
 
+* Changed the expectation of the value for an `:example` option of an attribute:
+  * Before, passing an array of values would indicate that those were a few possible examples for it.
+  * Now, any value (except the already existing special regexp or a proc) for an example will need to be of a native type (or coercible to it). This means that an attribute of type `Collection` can take an array example (and be taken as the whole thing)
+  * If anybody wants to provide multiple examples for an attribute they can write a proc, and make it return the different ones.
 
 ## 3.0.1
 

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -137,8 +137,7 @@ module Attributor
       when ::Regexp
         val.gen
       when ::Array
-        # TODO: handle arrays of non native types, i.e. arrays of regexps.... ?
-        val.pick
+        val
       when ::Proc
         if val.arity == 2
           val.call(parent, context)

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -136,8 +136,6 @@ module Attributor
       generated = case val
       when ::Regexp
         val.gen
-      when ::Array
-        val
       when ::Proc
         if val.arity == 2
           val.call(parent, context)

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -316,14 +316,10 @@ describe Attributor::Attribute do
 
     end
 
-    context 'with an array' do
+    context 'with an Collection (of Strings)' do
+      let(:type) { Attributor::Collection.of(String) }
       let(:example) { ["one"] }
-      let(:generated_example) { "one" }
-      it 'picks a random value' do
-        example.should_receive(:pick).and_call_original
-        example.should include example_result
-      end
-
+      it { should == example }
     end
 
   end


### PR DESCRIPTION
* Before the fix, one could not provide a native array as an example (although magically if passed as a string, it would actually decode properly)
* After the fix, native arrays will be used as the examples of the attribute.

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>