### PR TITLE
Add Regexp and Class types

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,14 @@ RSpec::Core::RakeTask.new do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
+desc "console"
+task :console do
+  require 'bundler'
+  Bundler.require(:default, :development, :test)
+  require_relative 'lib/attributor'
+  pry
+end
+
 task :default => :spec
 
 require 'yard'

--- a/attributor.gemspec
+++ b/attributor.gemspec
@@ -10,17 +10,18 @@ Gem::Specification.new do |spec|
   spec.authors = ["Josep M. Blanquer","Dane Jensen"]
   spec.summary = "A powerful attribute and type management library for Ruby"
   spec.email = ["blanquer@gmail.com","dane.jensen@gmail.com"]
-  
+
   spec.homepage = "https://github.com/rightscale/attributor"
   spec.license = "MIT"
   spec.required_ruby_version = ">=2.1"
-  
+
   spec.require_paths = ["lib"]
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  
+
   spec.add_runtime_dependency(%q<hashie>, ["~> 3"])
   spec.add_runtime_dependency(%q<randexp>, ["~> 0"])
+  spec.add_runtime_dependency(%q<activesupport>, ['>= 3'])
   spec.add_development_dependency(%q<rspec>, ["< 2.99"])
   spec.add_development_dependency(%q<yard>, ["~> 0.8.7"])
   spec.add_development_dependency(%q<backports>, ["~> 3"])

--- a/lib/attributor.rb
+++ b/lib/attributor.rb
@@ -45,7 +45,7 @@ module Attributor
   end
 
   def self.type_name(type)
-    return self.type_name(type.class) unless type.kind_of?(Class)
+    return self.type_name(type.class) unless type.kind_of?(::Class)
 
     type.ancestors.find { |k| k.name && !k.name.empty? }.name
   end
@@ -75,7 +75,7 @@ module Attributor
   end
 
   MODULE_PREFIX       = "Attributor\:\:".freeze
-  MODULE_PREFIX_REGEX = Regexp.new(MODULE_PREFIX)
+  MODULE_PREFIX_REGEX = ::Regexp.new(MODULE_PREFIX)
 
   require_relative 'attributor/families/numeric'
   require_relative 'attributor/families/temporal'
@@ -91,11 +91,13 @@ module Attributor
   require_relative 'attributor/types/time'
   require_relative 'attributor/types/date'
   require_relative 'attributor/types/date_time'
+  require_relative 'attributor/types/regexp'
   require_relative 'attributor/types/float'
   require_relative 'attributor/types/collection'
   require_relative 'attributor/types/hash'
   require_relative 'attributor/types/model'
   require_relative 'attributor/types/struct'
+  require_relative 'attributor/types/class'
 
 
   require_relative 'attributor/types/csv'

--- a/lib/attributor/types/class.rb
+++ b/lib/attributor/types/class.rb
@@ -1,4 +1,7 @@
+require 'active_support'
+
 require_relative '../exceptions'
+
 
 module Attributor
   class Class
@@ -9,24 +12,45 @@ module Attributor
     end
 
     def self.load(value, context=Attributor::DEFAULT_ROOT_CONTEXT, **options)
+      return @klass || nil if value.nil?
+
+      # Must be given a String object or nil
       unless value.kind_of?(::String) || value.nil?
         raise IncompatibleTypeError,  context: context, value_type: value.class, type: self
       end
 
       value = "::" + value if value[0..1] != '::'
+      result = value.constantize
 
-      value && eval(value)
-    rescue
-      super
+      # Class given must match class specified when type created using .of() method
+      unless @klass.nil? || result == @klass
+        raise LoadError, "Error loading class #{value} for attribute with " +
+          "defined class #{@klass} while loading #{Attributor.humanize_context(context)}."
+      end
+
+      result
     end
 
     def self.example(context=nil, options:{})
-      "MyClass"
+      @klass.nil? ? "MyClass" : @klass.name
+    end
+
+    # Create a Class attribute type of a specific Class.
+    #
+    # @param klass [Class] optional, defines the class of this attribute, if constant
+    #
+    # @return anonymous class with specified type of collection members
+    #
+    # @example Class.of(Factory)
+    #
+    def self.of(klass)
+      ::Class.new(self) do
+        @klass = klass
+      end
     end
 
     def self.family
       'string'
     end
-
   end
 end

--- a/lib/attributor/types/class.rb
+++ b/lib/attributor/types/class.rb
@@ -1,0 +1,32 @@
+require_relative '../exceptions'
+
+module Attributor
+  class Class
+    include Type
+
+    def self.native_type
+      return ::Class
+    end
+
+    def self.load(value, context=Attributor::DEFAULT_ROOT_CONTEXT, **options)
+      unless value.kind_of?(::String) || value.nil?
+        raise IncompatibleTypeError,  context: context, value_type: value.class, type: self
+      end
+
+      value = "::" + value if value[0..1] != '::'
+
+      value && eval(value)
+    rescue
+      super
+    end
+
+    def self.example(context=nil, options:{})
+      "MyClass"
+    end
+
+    def self.family
+      'string'
+    end
+
+  end
+end

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -16,7 +16,7 @@ module Attributor
       unless resolved_type.ancestors.include?(Attributor::Type)
         raise Attributor::AttributorException.new("Collections can only have members that are Attributor::Types")
       end
-      Class.new(self) do
+      ::Class.new(self) do
         @member_type = resolved_type
       end
     end
@@ -53,7 +53,7 @@ module Attributor
     def self.member_attribute
       @member_attribute ||= begin
         self.construct(nil,{})
-        
+
         @member_attribute
       end
     end

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -129,7 +129,7 @@ module Attributor
 
     # @example Hash.of(key: String, value: Integer)
     def self.of(key: @key_type, value: @value_type)
-      Class.new(self) do
+      ::Class.new(self) do
         self.key_type = key
         self.value_type = value
         @keys = {}
@@ -164,8 +164,8 @@ module Attributor
       example_depth = context.size
 
       self.keys.each do |sub_attribute_name, sub_attribute|
-        
-        
+
+
         if sub_attribute.attributes
           # TODO: add option to raise an exception in this case?
           next if example_depth > MAX_EXAMPLE_DEPTH

--- a/lib/attributor/types/ids.rb
+++ b/lib/attributor/types/ids.rb
@@ -12,7 +12,7 @@ module Attributor
         raise AttributorException, "#{type.name} does not have attribute with name '#{identity_name}'"
       end
 
-      Class.new(self) do
+      ::Class.new(self) do
         @member_attribute = identity_attribute
         @member_type = identity_attribute.type
       end

--- a/lib/attributor/types/regexp.rb
+++ b/lib/attributor/types/regexp.rb
@@ -1,0 +1,30 @@
+require_relative '../exceptions'
+
+module Attributor
+  class Regexp
+    include Type
+
+    def self.native_type
+      return ::Regexp
+    end
+
+    def self.load(value, context=Attributor::DEFAULT_ROOT_CONTEXT, **options)
+      unless value.kind_of?(::String) || value.nil?
+        raise IncompatibleTypeError,  context: context, value_type: value.class, type: self
+      end
+
+      value && ::Regexp.new(value, options[:regexp_opts])
+    rescue
+      super
+    end
+
+    def self.example(context=nil, options:{})
+      ::Regexp.new(/^pattern\d{0,3}$/).to_s
+    end
+
+    def self.family
+      'string'
+    end
+
+  end
+end

--- a/lib/attributor/types/regexp.rb
+++ b/lib/attributor/types/regexp.rb
@@ -13,7 +13,7 @@ module Attributor
         raise IncompatibleTypeError,  context: context, value_type: value.class, type: self
       end
 
-      value && ::Regexp.new(value, options[:regexp_opts])
+      value && ::Regexp.new(value)
     rescue
       super
     end

--- a/lib/attributor/types/struct.rb
+++ b/lib/attributor/types/struct.rb
@@ -1,8 +1,8 @@
 
 module Attributor
   class Struct < Attributor::Model
-    
-    def self.constructable? 
+
+    def self.constructable?
       true
     end
 
@@ -26,7 +26,7 @@ module Attributor
         end
       end
 
-      Class.new(self) do
+      ::Class.new(self) do
         attributes options, &attribute_definition
       end
 

--- a/spec/types/class_spec.rb
+++ b/spec/types/class_spec.rb
@@ -1,4 +1,5 @@
 require File.join(File.dirname(__FILE__), '..', 'spec_helper.rb')
+require 'backports'
 
 describe Attributor::Class do
 
@@ -11,25 +12,53 @@ describe Attributor::Class do
   end
 
   context '.example' do
-    it "should return a valid String" do
+    it "returns a valid String" do
       type.example.should be_a(::String)
+    end
+
+    context 'when created using .of method' do
+      let(:klass) { Integer }
+      subject(:type) { Attributor::Class.of(klass) }
+
+      it "returns the class specified" do
+        type.example.should eq(klass.to_s)
+      end
     end
   end
 
   context '.load' do
     let(:value) { nil }
 
+    context 'for incoming String values' do
+      ['Object', '::Object', '::Hash', 'Attributor::Struct'].each do |value|
+        it "loads '#{value}' as #{eval(value)}" do
+          type.load(value).should eq(value.constantize)
+        end
+      end
+    end
+
+    context 'when created using .of method' do
+      let(:klass) { Integer }
+      subject(:type) { Attributor::Class.of(klass) }
+
+      it "loads 'Integer' as Integer" do
+        type.load('Integer').should eq(Integer)
+      end
+
+      it "returns specified class for nil" do
+        type.load(nil).should be(klass)
+      end
+
+      it "raises when given a class that doesn't match specified class" do
+        expect { type.load('Float') }.to raise_exception(Attributor::LoadError)
+      end
+    end
+
     it 'returns nil for nil' do
       type.load(nil).should be(nil)
     end
 
-    context 'for incoming String values' do
-
-      ['Object', '::Object', '::Hash', 'Attributor::Struct'].each do |value|
-        it "loads '#{value}' as #{eval(value)}" do
-          type.load(value).should eq(eval(value))
-        end
-      end
+    it 'raises when given a non-String' do
     end
   end
 

--- a/spec/types/class_spec.rb
+++ b/spec/types/class_spec.rb
@@ -5,24 +5,17 @@ describe Attributor::Class do
 
   subject(:type) { Attributor::Class }
 
-  context '.native_type' do
-    it "returns Regexp" do
-      type.native_type.should be(::Class)
-    end
-  end
+  its(:native_type) { should be(::Class) }
+  its(:family) { should == 'string' }
 
   context '.example' do
-    it "returns a valid String" do
-      type.example.should be_a(::String)
-    end
+    its(:example) { should be_a(::String) }
 
     context 'when created using .of method' do
       let(:klass) { Integer }
       subject(:type) { Attributor::Class.of(klass) }
 
-      it "returns the class specified" do
-        type.example.should eq(klass.to_s)
-      end
+      its(:example) { should eq(klass.to_s) }
     end
   end
 
@@ -59,12 +52,7 @@ describe Attributor::Class do
     end
 
     it 'raises when given a non-String' do
-    end
-  end
-
-  context '.family' do
-    it 'returns "string" as the family' do
-      type.family.should == 'string'
+      expect {type.load(1)}.to raise_exception(Attributor::IncompatibleTypeError)
     end
   end
 end

--- a/spec/types/class_spec.rb
+++ b/spec/types/class_spec.rb
@@ -1,0 +1,41 @@
+require File.join(File.dirname(__FILE__), '..', 'spec_helper.rb')
+
+describe Attributor::Class do
+
+  subject(:type) { Attributor::Class }
+
+  context '.native_type' do
+    it "returns Regexp" do
+      type.native_type.should be(::Class)
+    end
+  end
+
+  context '.example' do
+    it "should return a valid String" do
+      type.example.should be_a(::String)
+    end
+  end
+
+  context '.load' do
+    let(:value) { nil }
+
+    it 'returns nil for nil' do
+      type.load(nil).should be(nil)
+    end
+
+    context 'for incoming String values' do
+
+      ['Object', '::Object', '::Hash', 'Attributor::Struct'].each do |value|
+        it "loads '#{value}' as #{eval(value)}" do
+          type.load(value).should eq(eval(value))
+        end
+      end
+    end
+  end
+
+  context '.family' do
+    it 'returns "string" as the family' do
+      type.family.should == 'string'
+    end
+  end
+end

--- a/spec/types/regexp_spec.rb
+++ b/spec/types/regexp_spec.rb
@@ -4,17 +4,9 @@ describe Attributor::Regexp do
 
   subject(:type) { Attributor::Regexp }
 
-  context '.native_type' do
-    it "returns Regexp" do
-      type.native_type.should be(::Regexp)
-    end
-  end
-
-  context '.example' do
-    it "should return a valid String" do
-      type.example.should be_a(::String)
-    end
-  end
+  its(:native_type) { should be(::Regexp) }
+  its(:example) { should be_a(::String) }
+  its(:family) { should == 'string' }
 
   context '.load' do
     let(:value) { nil }
@@ -31,12 +23,6 @@ describe Attributor::Regexp do
         end
       end
 
-    end
-  end
-
-  context '.family' do
-    it 'returns "string" as the family' do
-      type.family.should == 'string'
     end
   end
 end

--- a/spec/types/regexp_spec.rb
+++ b/spec/types/regexp_spec.rb
@@ -1,0 +1,51 @@
+require File.join(File.dirname(__FILE__), '..', 'spec_helper.rb')
+
+describe Attributor::Regexp do
+
+  subject(:type) { Attributor::Regexp }
+
+  context '.native_type' do
+    it "returns Regexp" do
+      type.native_type.should be(::Regexp)
+    end
+  end
+
+  context '.example' do
+    it "should return a valid String" do
+      type.example.should be_a(::String)
+    end
+  end
+
+  context '.load' do
+    let(:value) { nil }
+
+    it 'returns nil for nil' do
+      type.load(nil).should be(nil)
+    end
+
+    context 'for incoming String values' do
+
+      { 'foo' => /foo/, '^pattern$' => /^pattern$/ }.each do |value, expected|
+        it "loads '#{value}' as #{expected.inspect}" do
+          type.load(value).should eq(expected)
+        end
+      end
+
+      context 'given options' do
+        it 'loads String with a single option' do
+          type.load('foobar',{regexp_opts: Regexp::IGNORECASE}).should eq(/foobar/i)
+        end
+
+        it 'loads String with multiple options' do
+          type.load('foobar',{regexp_opts: Regexp::MULTILINE | Regexp::EXTENDED}).should eq(/foobar/mx)
+        end
+      end
+    end
+  end
+
+  context '.family' do
+    it 'returns "string" as the family' do
+      type.family.should == 'string'
+    end
+  end
+end

--- a/spec/types/regexp_spec.rb
+++ b/spec/types/regexp_spec.rb
@@ -31,15 +31,6 @@ describe Attributor::Regexp do
         end
       end
 
-      context 'given options' do
-        it 'loads String with a single option' do
-          type.load('foobar',{regexp_opts: Regexp::IGNORECASE}).should eq(/foobar/i)
-        end
-
-        it 'loads String with multiple options' do
-          type.load('foobar',{regexp_opts: Regexp::MULTILINE | Regexp::EXTENDED}).should eq(/foobar/mx)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Adds `Attributor::Regexp` and `Attributor::Class` types for use in config files.

Implements proposal here: #137 