### PR TITLE
Fix struct comparison against non-struct objects.

### DIFF
--- a/lib/attributor/types/struct.rb
+++ b/lib/attributor/types/struct.rb
@@ -45,7 +45,7 @@ module Attributor
 
     # Two structs are equal if their attributes are equal
     def ==(other_object)
-      return false if other_object == nil
+      return false if other_object == nil || !other_object.respond_to?(:attributes)
       self.attributes == other_object.attributes
     end
 


### PR DESCRIPTION
For example this currently raises an error if compared against the `anything` matcher for the current version of rspec: https://github.com/rspec/rspec-support/blob/08fe8c1477ea83091454c96be17dc2e4e9eb46b0/lib/rspec/support/fuzzy_matcher.rb#L15.

Signed-off-by: Alistair Scott <alistair@rightscale.com>