### PR TITLE
Better error when string example generation fails

### DIFF
--- a/lib/attributor/types/string.rb
+++ b/lib/attributor/types/string.rb
@@ -18,8 +18,12 @@ module Attributor
 
     def self.example(context=nil, options:{})
       if options[:regexp]
-        # It may fail to generate an example, see bug #72.
-        options[:regexp].gen rescue ('Failed to generate example for %s' % options[:regexp].inspect)
+        begin
+          # It may fail to generate an example, see bug #72.
+          options[:regexp].gen
+        rescue => e
+          'Failed to generate example for %s : %s' % [ options[:regexp].inspect, e.message]
+        end
       else
         /\w+/.gen
       end

--- a/spec/types/string_spec.rb
+++ b/spec/types/string_spec.rb
@@ -24,6 +24,7 @@ describe Attributor::String do
       expect {
         val = Attributor::String.example(options:{regexp: regex})
         val.should be_a(::String)
+        val.should =~ /Failed to generate.+is too vague/
       }.to_not raise_error
     end
 


### PR DESCRIPTION
Add more information to the generated string example (so that receiver can know how to fix it)

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>