### PR TITLE
Make Attributor::URI properly dump the :URI::Generic with `.to_s`

### DIFF
--- a/lib/attributor/types/uri.rb
+++ b/lib/attributor/types/uri.rb
@@ -38,6 +38,10 @@ module Attributor
       end
     end
 
+    def self.dump(value, **opts)
+      value.to_s
+    end
+
     def self.validate(value,context=Attributor::DEFAULT_ROOT_CONTEXT,attribute)
       errors = []
 

--- a/spec/types/uri_spec.rb
+++ b/spec/types/uri_spec.rb
@@ -12,6 +12,12 @@ describe Attributor::URI do
     end
   end
 
+  context '.dump' do
+    let(:example){ type.example }
+    it 'uses the underlying URI to_s' do
+      expect(type.dump(example)).to eq(example.to_s)
+    end
+  end
   context '.load' do
     subject(:load) { type.load(value) }
 


### PR DESCRIPTION
Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>