### PR TITLE
Advanced attribute requirements for `Struct/Model/Hash` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@
 * Added an "anonymous" DSL for base `Attributor::Type` which is reported in its `.describe` call.
   * This is a simple documentation bit, that might help the clients to document the type properly (i.e. treat it as if the type was anonymously defined whenever is used, rather than reachable by id/name from anywhere)
 
+* Built advanced attribute requirements for `Struct`,`Model` and `Hash` types. Those requirements allow you to define things like:
+  * A list of attributes that are required (equivalent to defining the required: true bit at each of the attributes)
+  * At most (n) attributes from a group can be passed in
+  * At least (n) attributes from a group are required
+  * Exactly (n) attributes from a group are required
+  * Example:
+  ```
+  requires ‘id’, ‘name’
+  requires.all ‘id’, ‘name’  # Equivalent to above
+  requires.all.of ‘id’, ‘name’  # Equivalent to above again
+  requires.at_most(2).of 'consistency', 'availability', 'partitioning'
+  requires.at_least(1).of ‘rock’, ‘pop’
+  requires.exactly(2).of ‘one’, ‘two’, ’three’
+  ```
+  * Same example expressed inside a block if so desired
+  ```
+  requires do
+    all 'id', 'name
+    all.of 'id', 'name # Equivalent
+    at_most(2).of 'consistency', 'availability', 'partitioning'
+    …
+  end
+  ```
+
 ## 4.1.0
 
 * Added a `Class` type (useful to avoid demodulization coercions etc...)

--- a/lib/attributor.rb
+++ b/lib/attributor.rb
@@ -11,6 +11,7 @@ module Attributor
   require_relative 'attributor/attribute'
   require_relative 'attributor/type'
   require_relative 'attributor/dsl_compiler'
+  require_relative 'attributor/hash_dsl_compiler'
   require_relative 'attributor/attribute_resolver'
 
   require_relative 'attributor/example_mixin'

--- a/lib/attributor/hash_dsl_compiler.rb
+++ b/lib/attributor/hash_dsl_compiler.rb
@@ -13,8 +13,8 @@ module Attributor
       attr_reader :attr_names
       attr_reader :description
 
-      def initialize(spec)
-        @description = spec.delete(:description)
+      def initialize(description: nil, **spec)
+        @description = description
         @type = spec.keys.first
         case type
         when :all

--- a/lib/attributor/hash_dsl_compiler.rb
+++ b/lib/attributor/hash_dsl_compiler.rb
@@ -61,6 +61,12 @@ module Attributor
         end
         result
       end
+
+      def describe(shallow=false, example: nil)
+        hash = {type: type, attributes: attr_names}
+        hash[:count] = number unless number.nil?
+        hash
+      end
     end
 
 

--- a/lib/attributor/hash_dsl_compiler.rb
+++ b/lib/attributor/hash_dsl_compiler.rb
@@ -1,0 +1,118 @@
+require_relative 'dsl_compiler'
+
+
+module Attributor
+
+  class HashDSLCompiler < DSLCompiler
+
+    class Requirement
+      attr_reader :type
+      attr_reader :number
+      attr_reader :attr_names
+
+      def initialize(spec)
+        @type = spec.keys.first
+        case type
+        when :all
+          self.of(*spec[type])
+        when :exclusive
+          self.of(*spec[type])
+        else
+          @number = spec[type]
+        end
+      end
+      def of( *args)
+        @attr_names = args
+        self
+      end
+
+      def validate( object,context=Attributor::DEFAULT_ROOT_CONTEXT,_attribute)
+        result = []
+        case type
+        when :all
+          rest = attr_names - object.keys
+          unless rest.empty?
+            rest.each do |attr|
+              result.push "Key #{attr} is required for #{Attributor.humanize_context(context)}."
+            end
+          end
+        when :exactly
+          included = attr_names & object.keys
+          unless included.size ==  number
+            result.push "Exactly #{number} of the following keys #{attr_names} are required for #{Attributor.humanize_context(context)}. Found #{included.size} instead: #{included.inspect}"
+          end
+        when :at_most
+          rest = attr_names & object.keys
+          if rest.size > number
+            found = rest.empty? ? "none" : rest.inspect
+            result.push "At most #{number} keys out of #{attr_names} can be passed in for #{Attributor.humanize_context(context)}. Found #{found}"
+          end
+        when :at_least
+          rest = attr_names & object.keys
+          if rest.size < number
+            found = rest.empty? ? "none" : rest.inspect
+            result.push "At least #{number} keys out of #{attr_names} are required to be passed in for #{Attributor.humanize_context(context)}. Found #{found}"
+          end
+        when :exclusive
+          intersection = attr_names & object.keys
+          if intersection.size > 1
+            result.push "keys #{intersection.inspect} are mutually exclusive for #{Attributor.humanize_context(context)}."
+          end
+        end
+        result
+      end
+    end
+
+
+    class RequiresDSL
+      attr_accessor :target
+      def initialize(target)
+        self.target = target
+      end
+      def all(*attr_names)
+        req = Requirement.new( all: attr_names )
+        target.add_requirement req
+        req
+      end
+      def at_most(number)
+        req = Requirement.new( at_most: number )
+        target.add_requirement req
+        req
+      end
+      def at_least(number)
+        req = Requirement.new( at_least: number )
+        target.add_requirement req
+        req
+      end
+      def exactly(number)
+        req = Requirement.new( exactly: number )
+        target.add_requirement req
+        req
+      end
+      def exclusive(*attr_names)
+        req = Requirement.new( exclusive: attr_names )
+        target.add_requirement req
+        req
+      end
+
+    end
+
+    def _requirements_dsl
+      @requirements_dsl ||= RequiresDSL.new(@target)
+    end
+
+    def requires(*spec,&block)
+      if spec.empty?
+        if block_given?
+          self._requirements_dsl.instance_eval(&block)
+        else
+          self._requirements_dsl
+        end
+      else
+        self._requirements_dsl.all(*spec)
+      end
+    end
+
+
+  end
+end

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -437,6 +437,9 @@ module Attributor
             sub_example = example.get(sub_name) if example
             sub_attributes[sub_name] = sub_attribute.describe(true, example: sub_example)
           end
+          hash[:requirements] = self.requirements.each_with_object([]) do |req, list|
+            list << req.describe(shallow)
+          end
         end
       else
         hash[:value] = {type: value_type.describe(true)}

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -147,7 +147,7 @@ module Attributor
       return unless req.attr_names
       non_existing = req.attr_names - self.attributes.keys
       unless non_existing.empty?
-        raise "Invalid attribute name/s found (#{non_existing.join(', ')}) when defining a requirement of type #{req.type} for #{Attributor.type_name(self)} ." +
+        raise "Invalid attribute name(s) found (#{non_existing.join(', ')}) when defining a requirement of type #{req.type} for #{Attributor.type_name(self)} ." +
         "The only existing attributes are #{self.attributes.keys}"
       end
 

--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -32,6 +32,7 @@ module Attributor
 
       v = self.value_type
       va = self.value_attribute
+      re = self.requirements
 
       klass.instance_eval do
         @saved_blocks = []
@@ -43,6 +44,7 @@ module Attributor
         @key_attribute = ka
         @value_attribute = va
 
+        @requirements = re
         @error = false
       end
     end

--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -32,7 +32,6 @@ module Attributor
 
       v = self.value_type
       va = self.value_attribute
-      re = self.requirements
 
       klass.instance_eval do
         @saved_blocks = []
@@ -44,7 +43,7 @@ module Attributor
         @key_attribute = ka
         @value_attribute = va
 
-        @requirements = re
+        @requirements = []
         @error = false
       end
     end

--- a/spec/hash_dsl_compiler_spec.rb
+++ b/spec/hash_dsl_compiler_spec.rb
@@ -22,22 +22,23 @@ describe Attributor::HashDSLCompiler do
       end
     end
 
-    context 'with params only' do
+    context 'with params only (and some options)' do
       it 'takes then array to mean all attributes are required' do
         target.should_receive(:add_requirement)
-        requirement = subject.requires [:one, :two]
+        requirement = subject.requires :one, :two , description: "These are very required"
         requirement.should be_kind_of( Attributor::HashDSLCompiler::Requirement )
         requirement.type.should be(:all)
       end
     end
-    context 'with a block only' do
+    context 'with a block only (and some options)' do
       it 'evals it in the context of the Compiler' do
         proc = Proc.new {}
         dsl = dsl_compiler._requirements_dsl
         dsl.should_receive(:instance_eval)#.with(&proc) << Does rspec 2.99 support block args?
-        subject.requires &proc
+        subject.requires description: "These are very required", &proc
       end
     end
+
 
   end
 
@@ -102,6 +103,11 @@ describe Attributor::HashDSLCompiler do
         req_class.new(at_least: 3).number.should be(3)
         req_class.new(at_least: 3).type.should be(:at_least)
       end
+      it 'understands and saves a :description' do
+        req = req_class.new(exactly:  1, description: "Hello")
+        req.number.should be(1)
+        req.description.should eq("Hello")
+      end
     end
 
     context 'Requirement#validate' do
@@ -161,6 +167,10 @@ describe Attributor::HashDSLCompiler do
       it 'should work for :at_least n' do
         req = req_class.new(at_least: 1).of(*attr_names).describe
         req.should include( type: :at_least,  count: 1, attributes: [:one, :two, :tree] )
+      end
+      it 'should report a description' do
+        req = req_class.new(at_least: 1, description: "no more than 1").of(*attr_names).describe
+        req.should include( type: :at_least,  count: 1, attributes: [:one, :two, :tree], description: "no more than 1" )
       end
     end
   end

--- a/spec/hash_dsl_compiler_spec.rb
+++ b/spec/hash_dsl_compiler_spec.rb
@@ -1,0 +1,143 @@
+require File.join(File.dirname(__FILE__), 'spec_helper.rb')
+
+
+describe Attributor::HashDSLCompiler do
+
+  let(:target) { double("model", attributes: {}) }
+
+  let(:dsl_compiler_options) { {} }
+  subject(:dsl_compiler) { Attributor::HashDSLCompiler.new(target, dsl_compiler_options) }
+
+  it 'returns the requirements DSL attached to the right target' do
+    req_dsl = dsl_compiler._requirements_dsl
+    req_dsl.should be_kind_of( Attributor::HashDSLCompiler::RequiresDSL )
+    req_dsl.target.should be(target)
+  end
+
+  context 'requires' do
+
+    context 'without any arguments' do
+      it 'without params returns the underlying compiler to chain internal methods' do
+        subject.requires.should be_kind_of( Attributor::HashDSLCompiler::RequiresDSL )
+      end
+    end
+
+    context 'with params only' do
+      it 'takes then array to mean all attributes are required' do
+        target.should_receive(:add_requirement)
+        requirement = subject.requires [:one, :two]
+        requirement.should be_kind_of( Attributor::HashDSLCompiler::Requirement )
+        requirement.type.should be(:all)
+      end
+    end
+    context 'with a block only' do
+      it 'evals it in the context of the Compiler' do
+        proc = Proc.new {}
+        dsl = dsl_compiler._requirements_dsl
+        dsl.should_receive(:instance_eval)#.with(&proc) << Does rspec 2.99 support block args?
+        subject.requires &proc
+      end
+    end
+
+  end
+
+  context 'RequiresDSL' do
+
+    subject(:dsl){ Attributor::HashDSLCompiler::RequiresDSL.new(target) }
+    it 'stores the received target' do
+      subject.target.should be(target)
+    end
+
+    context 'has DSL methods' do
+      let(:req){ double("requirement") }
+      let(:attr_names){ [:one, :two, :tree] }
+      let(:number){ 2 }
+      let(:req_class){ Attributor::HashDSLCompiler::Requirement }
+      before do
+        target.should_receive(:add_requirement).with(req)
+      end
+      it 'responds to .all' do
+        req_class.should_receive(:new).with( all: attr_names ).and_return(req)
+        subject.all(*attr_names)
+      end
+      it 'responds to .at_most(n)' do
+        req_class.should_receive(:new).with( at_most: number ).and_return(req)
+        subject.at_most(number)
+      end
+      it 'responds to .at_least(n)' do
+        req_class.should_receive(:new).with( at_least: number ).and_return(req)
+        subject.at_least(number)
+      end
+      it 'responds to .exactly(n)' do
+        req_class.should_receive(:new).with( exactly: number ).and_return(req)
+        subject.exactly(number)
+      end
+      it 'responds to .exclusive' do
+        req_class.should_receive(:new).with( exclusive: attr_names ).and_return(req)
+        subject.exclusive(*attr_names)
+      end
+
+    end
+  end
+
+  context 'Requirement' do
+
+    let(:attr_names){ [:one, :two, :tree] }
+    let(:req_class){ Attributor::HashDSLCompiler::Requirement }
+
+    context 'initialization' do
+      it 'calls .of for exclusive' do
+        req_class.any_instance.should_receive(:of).with(*attr_names)
+        req_class.new(exclusive: attr_names)
+      end
+      it 'calls .of for all' do
+        req_class.any_instance.should_receive(:of).with(*attr_names)
+        req_class.new(all: attr_names)
+      end
+      it 'saves the number for the rest' do
+        req_class.new(exactly:  1).number.should be(1)
+        req_class.new(exactly:  1).type.should be(:exactly)
+        req_class.new(at_most:  2).number.should be(2)
+        req_class.new(at_most:  2).type.should be(:at_most)
+        req_class.new(at_least: 3).number.should be(3)
+        req_class.new(at_least: 3).type.should be(:at_least)
+      end
+    end
+
+    context '#validate' do
+      let(:requirement){ req_class.new(arguments) }
+      let(:subject){ requirement.validate(value,["$"],nil)}
+
+      context 'for :all' do
+        let(:arguments){ { all: [:one, :two, :three] } }
+        let(:value){ {one: 1}}
+        let(:validation_error){ ["Key two is required for $.", "Key three is required for $."] }
+        it { subject.should include(*validation_error) }
+      end
+      context 'for :exactly' do
+        let(:requirement) { req_class.new(exactly: 1).of(:one,:two) }
+        let(:value){ {one: 1, two: 2}}
+        let(:validation_error){ "Exactly 1 of the following keys [:one, :two] are required for $. Found 2 instead: [:one, :two]" }
+        it { subject.should include(validation_error) }
+      end
+      context 'for :at_least' do
+        let(:requirement) { req_class.new(at_least: 2).of(:one,:two,:three) }
+        let(:value){ {one: 1}}
+        let(:validation_error){ "At least 2 keys out of [:one, :two, :three] are required to be passed in for $. Found [:one]" }
+        it { subject.should include(validation_error) }
+      end
+      context 'for :at_most' do
+        let(:requirement) { req_class.new(at_most: 1).of(:one,:two,:three) }
+        let(:value){ {one: 1, two: 2}}
+        let(:validation_error){ "At most 1 keys out of [:one, :two, :three] can be passed in for $. Found [:one, :two]" }
+        it { subject.should include(validation_error) }
+      end
+      context 'for :exclusive' do
+        let(:arguments){ { exclusive: [:one, :two] } }
+        let(:value){ {one: 1, two: 2}}
+        let(:validation_error){ "keys [:one, :two] are mutually exclusive for $." }
+        it { subject.should include(validation_error) }
+      end
+    end
+  end
+end

--- a/spec/hash_dsl_compiler_spec.rb
+++ b/spec/hash_dsl_compiler_spec.rb
@@ -104,7 +104,7 @@ describe Attributor::HashDSLCompiler do
       end
     end
 
-    context '#validate' do
+    context 'Requirement#validate' do
       let(:requirement){ req_class.new(arguments) }
       let(:subject){ requirement.validate(value,["$"],nil)}
 
@@ -137,6 +137,30 @@ describe Attributor::HashDSLCompiler do
         let(:value){ {one: 1, two: 2}}
         let(:validation_error){ "keys [:one, :two] are mutually exclusive for $." }
         it { subject.should include(validation_error) }
+      end
+    end
+
+    context 'Requirement#describe' do
+
+      it 'should work for :all' do
+        req = req_class.new(all: attr_names).describe
+        req.should eq( type: :all, attributes: [:one, :two, :tree] )
+      end
+      it 'should work for :exclusive n' do
+        req = req_class.new(exclusive: attr_names).describe
+        req.should eq( type: :exclusive, attributes: [:one, :two, :tree] )
+      end
+      it 'should work for :exactly' do
+        req = req_class.new(exactly: 1).of(*attr_names).describe
+        req.should include( type: :exactly,  count: 1, attributes: [:one, :two, :tree] )
+      end
+      it 'should work for :at_most n' do
+        req = req_class.new(at_most: 1).of(*attr_names).describe
+        req.should include( type: :at_most,  count: 1, attributes: [:one, :two, :tree] )
+      end
+      it 'should work for :at_least n' do
+        req = req_class.new(at_least: 1).of(*attr_names).describe
+        req.should include( type: :at_least,  count: 1, attributes: [:one, :two, :tree] )
       end
     end
   end

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -671,6 +671,13 @@ describe Attributor::Hash do
           key '1', Integer, min: 1, max: 20
           key 'some_date', DateTime
           key 'defaulted', String, default: 'default value'
+          requires do
+            all.of '1','some_date'
+            exclusive 'some_date', 'defaulted'
+            at_least(1).of 'a string', 'some_date'
+            at_most(2).of 'a string', 'some_date'
+            exactly(1).of 'a string', 'some_date'
+          end
         end
       end
 
@@ -680,13 +687,27 @@ describe Attributor::Hash do
         description[:name].should eq('Hash')
         description[:key].should eq(type:{name: 'String', id: 'Attributor-String', family: 'string'})
         description.should_not have_key(:value)
+      end
 
+      it 'describes the type attributes correctly' do
         attrs = description[:attributes]
 
         attrs['a string'].should eq(type: {name: 'String', id: 'Attributor-String', family: 'string'} )
         attrs['1'].should eq(type: {name: 'Integer', id: 'Attributor-Integer', family: 'numeric'}, options: {min: 1, max: 20}  )
         attrs['some_date'].should eq(type: {name: 'DateTime', id: 'Attributor-DateTime', family: 'temporal'})
         attrs['defaulted'].should eq(type: {name: 'String', id: 'Attributor-String', family: 'string'}, default: 'default value')
+      end
+
+      it 'describes the type requirements correctly' do
+
+        reqs = description[:requirements]
+        reqs.should be_kind_of(Array)
+        reqs.size.should be(5)
+        reqs.should include( type: :all, attributes: ['1','some_date'] )
+        reqs.should include( type: :exclusive, attributes: ['some_date','defaulted'] )
+        reqs.should include( type: :at_least, attributes: ['a string','some_date'], count: 1 )
+        reqs.should include( type: :at_most, attributes: ['a string','some_date'], count: 2 )
+        reqs.should include( type: :exactly, attributes: ['a string','some_date'], count: 1 )
       end
 
       context 'with an example' do

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -429,7 +429,7 @@ describe Attributor::Hash do
       it 'it complains loudly' do
         expect{
           HashWithStrings.add_requirement(req)
-        }.to raise_error("Invalid attribute name/s found (invalid, notgood) when defining a requirement of type all for HashWithStrings .The only existing attributes are [:name, :something]")
+        }.to raise_error("Invalid attribute name(s) found (invalid, notgood) when defining a requirement of type all for HashWithStrings .The only existing attributes are [:name, :something]")
       end
     end
   end


### PR DESCRIPTION
Those requirements allow you to define things like:
  * A list of attributes that are required (equivalent to defining the required: true bit at each of the attributes)
  * At most (n) attributes from a group can be passed in
  * At least (n) attributes from a group are required
  * Exactly (n) attributes from a group are required
  * Example:
    * `requires ‘id’, ‘name’`
    * `requires.all ‘id’, ‘name’  # Equivalent to above`
    * `requires.at_most(2).of 'consistency', 'availability', 'partitioning'`
    * `requires.at_least(1).of ‘rock’, ‘pop’`
    * `requires.exactly(2).of ‘one’, ‘two’, ’three’`
  * Same example expressed inside a block if so desired
```
  requires do
    all 'id', 'name
    at_most(2).of 'consistency', 'availability', 'partitioning'
    …
  end
```

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>