### PR TITLE
Struct/Models will now validate entries using the `requires` DSL

### DIFF
--- a/lib/attributor/hash_dsl_compiler.rb
+++ b/lib/attributor/hash_dsl_compiler.rb
@@ -30,7 +30,7 @@ module Attributor
         self
       end
 
-      def validate( object,context=Attributor::DEFAULT_ROOT_CONTEXT,_attribute)
+      def validate( object,context=Attributor::DEFAULT_ROOT_CONTEXT,_attribute=nil)
         result = []
         case type
         when :all

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -590,11 +590,9 @@ module Attributor
           end
         end
       end
-      unless self.class.requirements.empty?
-        self.class.requirements.each_with_object(ret) do |req, errors|
-          validation_errors = req.validate( @contents , context)
-          errors.push *validation_errors unless validation_errors.empty?
-        end
+      self.class.requirements.each_with_object(ret) do |req, errors|
+        validation_errors = req.validate( @contents , context)
+        errors.push *validation_errors unless validation_errors.empty?
       end
       ret
     end

--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -141,11 +141,9 @@ module Attributor
 
         errors.push *sub_attribute.validate(value, sub_context)
       end
-      unless self.class.requirements.empty?
-        self.class.requirements.each_with_object(ret) do |req, errors|
-          validation_errors = req.validate( @contents , context)
-          errors.push *validation_errors unless validation_errors.empty?
-        end
+      self.class.requirements.each_with_object(ret) do |req, errors|
+        validation_errors = req.validate( @contents , context)
+        errors.push *validation_errors unless validation_errors.empty?
       end
       ret
     ensure

--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -131,7 +131,7 @@ module Attributor
 
       context = [context] if context.is_a? ::String
 
-      self.class.attributes.each_with_object(Array.new) do |(sub_attribute_name, sub_attribute), errors|
+      ret = self.class.attributes.each_with_object(Array.new) do |(sub_attribute_name, sub_attribute), errors|
         sub_context = self.class.generate_subcontext(context,sub_attribute_name)
 
         value = self.__send__(sub_attribute_name)
@@ -141,6 +141,13 @@ module Attributor
 
         errors.push *sub_attribute.validate(value, sub_context)
       end
+      unless self.class.requirements.empty?
+        self.class.requirements.each_with_object(ret) do |req, errors|
+          validation_errors = req.validate( @contents , context)
+          errors.push *validation_errors unless validation_errors.empty?
+        end
+      end
+      ret
     ensure
       @validating = false
     end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -83,6 +83,7 @@ class Address < Attributor::Model
     attribute :name, String, example: /\w+/
     attribute :state, String, values: %w{OR CA}
     attribute :person, Person, example: proc { |address, context| Person.example(context, address: address) }
+    requires :name
   end
 end
 

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -246,7 +246,7 @@ describe Attributor::Model do
         context 'loading with default values' do
           let(:reference) { Post }
           let(:options) { {reference: reference} }
-          
+
           let(:attribute_definition) do
             proc do
               attribute :title
@@ -255,10 +255,10 @@ describe Attributor::Model do
           end
 
           let(:struct) { Attributor::Struct.construct(attribute_definition, options)}
-          
+
           let(:data) { {title: 'my post'} }
-          
-          subject(:loaded)  { struct.load(data) }    
+
+          subject(:loaded)  { struct.load(data) }
 
 
           it 'validates' do
@@ -372,6 +372,11 @@ describe Attributor::Model do
       end
     end
 
+    context 'for models using the "requires" DSL' do
+      subject(:address) { Address.load(state: 'CA') }
+      its(:validate) { should_not be_empty }
+      its(:validate) { should include "Key name is required for $." }
+    end
     context 'for models with circular sub-attributes' do
       context 'that are valid' do
         subject(:person) { Person.example }


### PR DESCRIPTION
Allow Structs/Models to enforce any requirements described through the `requires` DSL:
* Adds processing of `requirements` in the overloaded `validate` function of Model.

Fixes #152

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>