### PR TITLE
Introduce the `Dumpable` (empty) module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## next
 
+* Introduce the `Dumpable` (empty) module as an interface to indicate that instances of types that include it
+will respond to the `.dump` method, as a way to convert their internal substructure to primitive Ruby objects.    * Currently the only two directly dumpable types are Collection and Hash (with the caveat that there are several others that derive from them..i.e., CSV, Model, etc...)
+  * The rest of types have `native_types` that are already Ruby primitive Objects.
+
+
 ## 5.0.1
 
 * Fix bug that made Struct/Models skip validation of requirements using the `requires` DSL

--- a/lib/attributor.rb
+++ b/lib/attributor.rb
@@ -7,6 +7,8 @@ require 'digest/sha1'
 
 module Attributor
 
+  require_relative 'attributor/dumpable'
+
   require_relative 'attributor/exceptions'
   require_relative 'attributor/attribute'
   require_relative 'attributor/type'

--- a/lib/attributor/dumpable.rb
+++ b/lib/attributor/dumpable.rb
@@ -1,0 +1,11 @@
+module Attributor
+  module Dumpable
+    # Interface denoting that instances of such type respond to .dump as a way to properly
+    # serialize its contents into primitive ruby objects.
+    # This typically corresponds to non-trivial types that have some sort of substructure
+    def dump
+      raise NotImplementedError, 'Dumpable requires the implementation of #dump'
+    end
+
+  end
+end

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -5,6 +5,7 @@ module Attributor
 
   class Collection < Array
     include Container
+    include Dumpable
 
     # @param type [Attributor::Type] optional, defines the type of all collection members
     # @return anonymous class with specified type of collection members

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -22,6 +22,7 @@ module Attributor
 
     include Container
     include Enumerable
+    include Dumpable
 
     class << self
       attr_reader :key_type, :value_type, :options

--- a/spec/dumpable_spec.rb
+++ b/spec/dumpable_spec.rb
@@ -1,0 +1,30 @@
+require File.join(File.dirname(__FILE__), 'spec_helper.rb')
+
+describe 'Dumpable' do
+
+  context 'for classes forgetting to implement #dump' do
+    let(:type) {
+      Class.new do
+        include Attributor::Dumpable
+      end
+     }
+
+    it 'gets an exception' do
+      expect{ type.new.dump }.to raise_exception(NotImplementedError)
+    end
+  end
+
+  context 'for classes properly implementing #dump' do
+    let(:type) {
+      Class.new do
+        include Attributor::Dumpable
+        def dump
+        end
+      end
+     }
+
+    it 'do not get the base exception' do
+      expect{ type.new.dump }.to_not raise_exception(NotImplementedError)
+    end
+  end
+end

--- a/spec/types/bigdecimal_spec.rb
+++ b/spec/types/bigdecimal_spec.rb
@@ -3,13 +3,17 @@ require File.join(File.dirname(__FILE__), '..', 'spec_helper.rb')
 describe Attributor::BigDecimal do
   subject(:type) { Attributor::BigDecimal }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   context '.native_type' do
     its(:native_type) { should be(::BigDecimal) }
   end
 
   context '.example' do
     its(:example) { should be_a(::BigDecimal) }
-    it do 
+    it do
       ex = type.example
     end
   end
@@ -19,7 +23,7 @@ describe Attributor::BigDecimal do
     it 'returns nil for nil' do
       type.load(nil).should be(nil)
     end
-    
+
     context 'for incoming Float values' do
      it 'returns the incoming value' do
        [0.0, -1.0, 1.0, 1e-10, 0.25135].each do |value|
@@ -36,7 +40,7 @@ describe Attributor::BigDecimal do
       end
     end
 
-    context 'for incoming String values' do 
+    context 'for incoming String values' do
       it 'should equal the value' do
         type.load('0').should eq(0)
         type.load('100').should eq(100)

--- a/spec/types/boolean_spec.rb
+++ b/spec/types/boolean_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::Boolean do
 
   subject(:type) { Attributor::Boolean }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   context '.valid_type?' do
 
     context 'for incoming Boolean values' do

--- a/spec/types/class_spec.rb
+++ b/spec/types/class_spec.rb
@@ -5,6 +5,10 @@ describe Attributor::Class do
 
   subject(:type) { Attributor::Class }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   its(:native_type) { should be(::Class) }
   its(:family) { should == 'string' }
 

--- a/spec/types/collection_spec.rb
+++ b/spec/types/collection_spec.rb
@@ -341,6 +341,10 @@ describe Attributor::Collection do
   context 'dumping' do
     let(:type) { Attributor::Collection.of(Cormorant) }
 
+    it 'it is Dumpable' do
+      type.new.is_a?(Attributor::Dumpable).should be(true)
+    end
+
     subject(:example) { type.example }
     it 'dumps' do
       expect {

--- a/spec/types/date_spec.rb
+++ b/spec/types/date_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::Date do
 
   subject(:type) { Attributor::Date }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   context '.native_type' do
     its(:native_type) { should be(::Date) }
   end
@@ -20,7 +24,7 @@ describe Attributor::Date do
     end
     context 'nil values' do
       it 'should be nil' do
-        type.dump(nil).should be_nil 
+        type.dump(nil).should be_nil
       end
     end
   end
@@ -33,14 +37,14 @@ describe Attributor::Date do
     end
 
     context 'for incoming objects' do
-      
+
       it "returns correct Date for Time objects" do
         object = Time.now
         loaded = type.load(object)
         loaded.should be_a(::Date)
         loaded.to_date.should == object.to_date
       end
-     
+
       it "returns correct Date for DateTime objects" do
         object = DateTime.now
         loaded = type.load(object)
@@ -48,8 +52,8 @@ describe Attributor::Date do
         loaded.should be(object)
       end
 
-    end    
-    
+    end
+
     context 'for incoming strings' do
 
       [

--- a/spec/types/date_time_spec.rb
+++ b/spec/types/date_time_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::DateTime do
 
   subject(:type) { Attributor::DateTime }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   context '.native_type' do
     its(:native_type) { should be(::DateTime) }
   end
@@ -20,7 +24,7 @@ describe Attributor::DateTime do
     end
     context 'nil values' do
       it 'should be nil' do
-        type.dump(nil).should be_nil 
+        type.dump(nil).should be_nil
       end
     end
   end
@@ -33,14 +37,14 @@ describe Attributor::DateTime do
     end
 
     context 'for incoming objects' do
-      
+
       it "returns correct DateTime for Time objects" do
         object = Time.now
         loaded = type.load(object)
         loaded.should be_a(::DateTime)
         loaded.to_time.should == object
       end
-     
+
       it "returns correct DateTime for DateTime objects" do
         object = DateTime.now
         loaded = type.load(object)
@@ -48,8 +52,8 @@ describe Attributor::DateTime do
         loaded.should be( object )
       end
 
-    end    
-    
+    end
+
     context 'for incoming strings' do
 
       [

--- a/spec/types/float_spec.rb
+++ b/spec/types/float_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::Float do
 
   subject(:type) { Attributor::Float }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   context '.native_type' do
     its(:native_type) { should be(::Float) }
   end

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -439,6 +439,10 @@ describe Attributor::Hash do
     let(:value) { {one: 1, two: 2} }
     let(:opts) { {} }
 
+    it 'it is Dumpable' do
+      type.new.is_a?(Attributor::Dumpable).should be(true)
+    end
+
     context 'for a simple (untyped) hash' do
       it 'returns the untouched hash value' do
         type.dump(value, opts).should eq(value)

--- a/spec/types/integer_spec.rb
+++ b/spec/types/integer_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::Integer do
 
   subject(:type) { Attributor::Integer }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   context '.example' do
 
     context 'when :min and :max are unspecified' do

--- a/spec/types/regexp_spec.rb
+++ b/spec/types/regexp_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::Regexp do
 
   subject(:type) { Attributor::Regexp }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   its(:native_type) { should be(::Regexp) }
   its(:example) { should be_a(::String) }
   its(:family) { should == 'string' }

--- a/spec/types/string_spec.rb
+++ b/spec/types/string_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::String do
 
   subject(:type) { Attributor::String }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   context '.native_type' do
     it "returns String" do
       type.native_type.should be(::String)

--- a/spec/types/time_spec.rb
+++ b/spec/types/time_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::Time do
 
   subject(:type) { Attributor::Time }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   context '.native_type' do
     its(:native_type) { should be(::Time) }
   end
@@ -20,7 +24,7 @@ describe Attributor::Time do
     end
     context 'nil values' do
       it 'should be nil' do
-        type.dump(nil).should be_nil 
+        type.dump(nil).should be_nil
       end
     end
   end
@@ -33,14 +37,14 @@ describe Attributor::Time do
     end
 
     context 'for incoming objects' do
-      
+
       it "returns correct Time for DateTime objects" do
         object = Time.now
         loaded = type.load(object)
         loaded.should be_a(::Time)
         loaded.to_time.should == object
       end
-     
+
       it "returns correct Time for DateTime objects" do
         object = DateTime.now
         loaded = type.load(object)
@@ -48,8 +52,8 @@ describe Attributor::Time do
         loaded.should eq(object.to_time)
       end
 
-    end    
-    
+    end
+
     context 'for incoming strings' do
 
       [

--- a/spec/types/uri_spec.rb
+++ b/spec/types/uri_spec.rb
@@ -4,6 +4,10 @@ describe Attributor::URI do
 
   subject(:type) { Attributor::URI }
 
+  it 'it is not Dumpable' do
+    type.new.is_a?(Attributor::Dumpable).should_not be(true)
+  end
+
   its(:native_type) { should be ::URI::Generic }
 
   context '.example' do


### PR DESCRIPTION
* This module serves as an interface to indicate that instances of types that include it
will respond to the `.dump` method, as a way to convert their internal substructure to primitive Ruby objects.
* This makes other tools able to further invoke the dump method of the object (or not), when rendering nested structures.

fixes #157 

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>