### PR TITLE
`.example` method signature for `_options` kw

### DIFF
--- a/lib/attributor/extras/field_selector.rb
+++ b/lib/attributor/extras/field_selector.rb
@@ -16,7 +16,7 @@ module Attributor
       ::Hash
     end
 
-    def self.example(_context = nil, _options = {})
+    def self.example(_context = nil, **_options)
       3.times.each_with_object([]) do |_i, array|
         array << /\w{5,8}/.gen
       end.join(',')

--- a/lib/attributor/types/symbol.rb
+++ b/lib/attributor/types/symbol.rb
@@ -12,7 +12,7 @@ module Attributor
       super
     end
 
-    def self.example(_context = nil, _options: {})
+    def self.example(_context = nil, **_options )
       :example
     end
 

--- a/lib/attributor/types/tempfile.rb
+++ b/lib/attributor/types/tempfile.rb
@@ -8,7 +8,7 @@ module Attributor
       ::Tempfile
     end
 
-    def self.example(context = Attributor::DEFAULT_ROOT_CONTEXT, _options: {})
+    def self.example(context = Attributor::DEFAULT_ROOT_CONTEXT, **_options)
       file = ::Tempfile.new(Attributor.humanize_context(context))
       file.write Randgen.sentence
       file.write '.'

--- a/lib/attributor/types/time.rb
+++ b/lib/attributor/types/time.rb
@@ -8,7 +8,7 @@ module Attributor
       ::Time
     end
 
-    def self.example(context = nil, _options: {})
+    def self.example(context = nil, **_options)
       load(Randgen.time, context)
     end
 

--- a/lib/attributor/types/uri.rb
+++ b/lib/attributor/types/uri.rb
@@ -22,7 +22,7 @@ module Attributor
       ::URI::Generic
     end
 
-    def self.example(_context = nil, _options = {})
+    def self.example(_context = nil, **_options)
       URI(Randgen.uri)
     end
 


### PR DESCRIPTION
Fixed the `.example` method signature after the previous refactoring of a couple days ago.
Some types (symbol, temple and time) had incorrectly been refactored to have a kw argument called `_options`

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>