### PR TITLE
Tidy up “type” `example` signature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,8 @@ Metrics/AbcSize:
   Enabled: false
 Style/CaseEquality:
   Enabled: false
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true
 
 # Offense count: 13
 Metrics/CyclomaticComplexity:

--- a/lib/attributor/extras/field_selector.rb
+++ b/lib/attributor/extras/field_selector.rb
@@ -16,7 +16,7 @@ module Attributor
       ::Hash
     end
 
-    def self.example(_context = nil, _options = {})
+    def self.example(_context = nil, options: {})
       3.times.each_with_object([]) do |_i, array|
         array << /\w{5,8}/.gen
       end.join(',')

--- a/lib/attributor/type.rb
+++ b/lib/attributor/type.rb
@@ -65,7 +65,7 @@ module Attributor
       end
 
       # Default, overridable example function
-      def example(_context = nil, **_options)
+      def example(_context = nil, options: {})
         raise AttributorException, "#{self} must implement #example"
       end
 

--- a/lib/attributor/types/bigdecimal.rb
+++ b/lib/attributor/types/bigdecimal.rb
@@ -6,7 +6,7 @@ module Attributor
       ::BigDecimal
     end
 
-    def self.example(_context = nil, **_options)
+    def self.example(_context = nil, options: {})
       ::BigDecimal.new("#{/\d{3}/.gen}.#{/\d{3}/.gen}")
     end
 

--- a/lib/attributor/types/boolean.rb
+++ b/lib/attributor/types/boolean.rb
@@ -10,7 +10,7 @@ module Attributor
       value == true || value == false
     end
 
-    def self.example(_context = nil, **_options)
+    def self.example(_context = nil, options: {})
       [true, false].sample
     end
 

--- a/lib/attributor/types/class.rb
+++ b/lib/attributor/types/class.rb
@@ -31,7 +31,7 @@ module Attributor
       result
     end
 
-    def self.example(_context = nil, **_options)
+    def self.example(_context = nil, options: {})
       @klass.nil? ? 'MyClass' : @klass.name
     end
 

--- a/lib/attributor/types/date.rb
+++ b/lib/attributor/types/date.rb
@@ -6,7 +6,7 @@ module Attributor
       ::Date
     end
 
-    def self.example(context = nil, **_options)
+    def self.example(context = nil, options: {})
       load(Randgen.date, context)
     end
 

--- a/lib/attributor/types/date_time.rb
+++ b/lib/attributor/types/date_time.rb
@@ -10,7 +10,7 @@ module Attributor
       ::DateTime
     end
 
-    def self.example(context = nil, **_options)
+    def self.example(context = nil, options: {})
       load(Randgen.date, context)
     end
 

--- a/lib/attributor/types/object.rb
+++ b/lib/attributor/types/object.rb
@@ -10,7 +10,7 @@ module Attributor
       ::BasicObject
     end
 
-    def self.example(_context = nil, **_options)
+    def self.example(_context = nil, options: {})
       'An Object'
     end
   end

--- a/lib/attributor/types/regexp.rb
+++ b/lib/attributor/types/regexp.rb
@@ -18,7 +18,7 @@ module Attributor
       super
     end
 
-    def self.example(_context = nil, **_options)
+    def self.example(_context = nil, options: {})
       ::Regexp.new(/^pattern\d{0,3}$/).to_s
     end
 

--- a/lib/attributor/types/symbol.rb
+++ b/lib/attributor/types/symbol.rb
@@ -12,7 +12,7 @@ module Attributor
       super
     end
 
-    def self.example(_context = nil, _options: {})
+    def self.example(_context = nil, options: {})
       :example
     end
 

--- a/lib/attributor/types/tempfile.rb
+++ b/lib/attributor/types/tempfile.rb
@@ -8,7 +8,7 @@ module Attributor
       ::Tempfile
     end
 
-    def self.example(context = Attributor::DEFAULT_ROOT_CONTEXT, _options: {})
+    def self.example(context = Attributor::DEFAULT_ROOT_CONTEXT, options: {})
       file = ::Tempfile.new(Attributor.humanize_context(context))
       file.write Randgen.sentence
       file.write '.'

--- a/lib/attributor/types/time.rb
+++ b/lib/attributor/types/time.rb
@@ -8,7 +8,7 @@ module Attributor
       ::Time
     end
 
-    def self.example(context = nil, _options: {})
+    def self.example(context = nil, options: {})
       load(Randgen.time, context)
     end
 

--- a/lib/attributor/types/uri.rb
+++ b/lib/attributor/types/uri.rb
@@ -22,7 +22,7 @@ module Attributor
       ::URI::Generic
     end
 
-    def self.example(_context = nil, _options = {})
+    def self.example(_context = nil, options: {})
       URI(Randgen.uri)
     end
 


### PR DESCRIPTION
Change “type” `example` signature to explicitly take a keyword argument for true type options everywhere.

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>