### PR TITLE
Fix Polymorphic doc description

### DIFF
--- a/lib/attributor/types/polymorphic.rb
+++ b/lib/attributor/types/polymorphic.rb
@@ -88,7 +88,7 @@ module Attributor
 
     def self.describe_types
       self.types.each_with_object({}) do |(key, value), description|
-        description[key] = value.describe(true)
+        description[key] = { type: value.describe(true) }
       end
     end
   end

--- a/spec/types/polymorphic_spec.rb
+++ b/spec/types/polymorphic_spec.rb
@@ -57,9 +57,9 @@ describe Attributor::Polymorphic do
       subject(:types) { description[:types] }
       its(:keys) { should eq type.types.keys }
       it do
-        expect(types[:chicken]).to eq(Chicken.describe(true))
-        expect(types[:turkey]).to eq(Turkey.describe(true))
-        expect(types[:duck]).to eq(Duck.describe(true))
+        expect(types[:chicken]).to eq(type: Chicken.describe(true))
+        expect(types[:turkey]).to eq(type: Turkey.describe(true))
+        expect(types[:duck]).to eq(type: Duck.describe(true))
       end
     end
 
@@ -70,9 +70,9 @@ describe Attributor::Polymorphic do
         subject(:types) { description[:types] }
         its(:keys) { should match_array [:chicken, :turkey, :duck] }
         it do
-          expect(types[:chicken]).to eq(Chicken.describe(true))
-          expect(types[:turkey]).to eq(Turkey.describe(true))
-          expect(types[:duck]).to eq(Duck.describe(true))
+          expect(types[:chicken]).to eq(type: Chicken.describe(true))
+          expect(types[:turkey]).to eq(type: Turkey.describe(true))
+          expect(types[:duck]).to eq(type: Duck.describe(true))
         end
       end
     end


### PR DESCRIPTION
Describe the different types in a Polymorphic type with the appropriate `type` markers so that the Doc generator can detect and report them.

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>