### PR TITLE
More robust “undefinition” of methods for `Model`

### DIFF
--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -1,9 +1,9 @@
 module Attributor
   class Model < Hash
     # FIXME: this is not the way to fix this. Really we should add finalize! to Models.
-    undef :timeout
-    undef :format
     begin
+      undef :timeout
+      undef :format
       undef :test
     rescue
       nil


### PR DESCRIPTION
Make sure we don't bomb if any of those common method have somehow already been undefined or are not there at all.

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>