### PR TITLE
Include full example for Collections

### DIFF
--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -108,7 +108,10 @@ module Attributor
     def self.describe(shallow = false, example: nil)
       hash = super(shallow)
       hash[:options] = {} unless hash[:options]
-      member_example = example.first if example
+      if example
+        hash[:example] = example
+        member_example = example.first
+      end
       hash[:member_attribute] = member_attribute.describe(true, example: member_example)
       hash
     end

--- a/spec/types/collection_spec.rb
+++ b/spec/types/collection_spec.rb
@@ -312,6 +312,7 @@ describe Attributor::Collection do
     subject(:described) { type.describe(example: example) }
     it 'includes the member_attribute' do
       expect(described).to have_key(:member_attribute)
+      expect(described).not_to have_key(:example)
       expect(described[:member_attribute]).not_to have_key(:example)
     end
 
@@ -321,6 +322,10 @@ describe Attributor::Collection do
         expect(described).to have_key(:member_attribute)
         expect(described[:member_attribute]).to have_key(:example)
         expect(described[:member_attribute]).to eq(type.member_attribute.describe(example: example.first))
+      end
+      it 'includes the incoming example for the whole collection as well' do
+        expect(described).to have_key(:example)
+        expect(described[:example]).to eq(example)
       end
     end
   end


### PR DESCRIPTION
Save the incoming example in the description of the Collection (so that there’s a full collection example available, not only an example of a single member inside the member_attribute)

closes rightscale/praxis#292

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>